### PR TITLE
feat(scheduler): add fire-and-forget Pi wakes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,9 @@ AI context for this repository. Read this before making changes.
 
 - `justfile` — explicit Pi launch profiles grouped by intent
 - `extensions/codex-search/` — bounded, shell-free Codex research fallback
+- `extensions/scheduler/` — opt-in fire-and-forget `bq` scheduler wake adapter
 - `extensions/subagents/` — asynchronous native Pi RPC conversation lifecycle
+- `docs/scheduler/CONTEXT.md` — canonical scheduler terminology and Queue boundary
 - `docs/subagents/CONTEXT.md` — canonical subagent terminology and boundaries
 - `docs/orchestration-exploration.md` — durable orchestration findings
 - `docs/research/` — cited assessments of reviewed reference material

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -2,4 +2,5 @@
 
 ## Contexts
 
+- [Pi Scheduler](./docs/scheduler/CONTEXT.md) — defines the language and Queue boundary for fire-and-forget scheduler wakes delivered to a live Pi session
 - [Pi Subagents](./docs/subagents/CONTEXT.md) — defines the language for the internal extension that starts and observes independent Pi agent conversations

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ just bare         # Only the /exit alias extension
 just core         # AGENTS.md and the /exit alias extension
 just research     # Core plus research skill and browser extension
 just orchestrate  # Core plus handoff, tmux-worker, and wormhole skills
+just scheduler    # Core plus the fire-and-forget scheduler wake extension
 just subagents    # Core plus the asynchronous subagent extension
 ```
 
@@ -60,6 +61,74 @@ behavior:
 just p
 just pi
 ```
+
+## Scheduler wakes
+
+`just scheduler` explicitly enables the extension in `extensions/scheduler/`.
+It exposes one `scheduler_submit` tool for immediate heartbeats, delayed or
+absolute-time work, finite repetition, and cron schedules. The extension invokes
+the existing global `bq` executable directly without a shell and returns as soon
+as `bq` reports acceptance or failure. It never waits for payload completion,
+watches OMQueue, polls Job state, or exposes Queue administration.
+
+Every submission requires a complete, self-contained `reentryPrompt`. An
+optional payload contains an executable, literal arguments, and a working
+directory; omitting it creates a heartbeat-only wake. Timing fields are passed to
+`bq`, which remains responsible for syntax and validation:
+
+```json
+{
+  "reentryPrompt": "Recheck service health against the incident criteria and report the next safe action.",
+  "timing": { "in": "15m" }
+}
+```
+
+```json
+{
+  "reentryPrompt": "Review the check result and decide whether deployment may continue.",
+  "timing": { "in": "1h", "every": "30m", "count": 4 },
+  "payload": {
+    "executable": "./check-service",
+    "args": ["--format", "json"],
+    "cwd": "./service"
+  }
+}
+```
+
+```json
+{
+  "reentryPrompt": "Run the weekday review, summarize failures, and identify the owner for each next action.",
+  "timing": { "cron": "0 9 * * 1-5", "tz": "America/Sao_Paulo" },
+  "payload": { "executable": "./weekday-review" }
+}
+```
+
+The queued callback runner forwards payload stdout and stderr for OMQueue capture
+while retaining only 4,000-byte previews for the wake. The required reentry
+prompt is limited to 8,000 UTF-8 bytes. The tool response preserves bounded `bq`
+stdout (16,000 bytes), stderr (8,000 bytes), and exit status. No shell command
+strings or custom payload environment are accepted. `bq` receives an explicit
+allowlist of normal process settings; payloads receive only `HOME`, locale,
+user/shell, `PATH`, `PROJECTS_DIR`, temporary-directory, and time-zone settings.
+Credentials and arbitrary submitting-shell variables are not forwarded.
+
+Callbacks use a mode-`0600` Unix socket inside a private temporary directory and
+a versioned, bounded frame correlated with session capability material carried
+explicitly in the queued argument vector. The endpoint exists only for the live
+owning Pi session and is removed on session shutdown. A wake is therefore best
+effort: Pi shutdown, host loss, a missing callback runner, forced runner
+termination, or failure before the runner starts can prevent delivery. Durable
+OMQueue payloads and recurring schedules may continue after Pi closes, but their
+callbacks cannot reopen the session. Manage or cancel such schedules outside
+this extension through explicitly requested ordinary shell or OMQueue
+administration.
+
+The callback runner path is stored in each accepted Job or Schedule and must
+remain executable at that absolute location. Scheduler submissions inherit the
+user's command authority and are not sandboxed. This extension is not enabled by
+any unrelated launch profile or by package discovery in this repository. When a
+user explicitly asks to invoke or inspect raw `bq`, use ordinary bash rather
+than `scheduler_submit`.
 
 ## Asynchronous subagents
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ just pi
 It exposes one `scheduler_submit` tool for immediate heartbeats, delayed or
 absolute-time work, finite repetition, and cron schedules. The extension invokes
 the existing global `bq` executable directly without a shell and returns as soon
-as `bq` reports acceptance or failure. It never waits for payload completion,
+as `bq` exits. A zero exit confirms acceptance. Any other result leaves acceptance
+unknown because finite submission may already have created durable work; do not
+blindly retry an unknown result. The extension never waits for payload completion,
 watches OMQueue, polls Job state, or exposes Queue administration.
 
 Every submission requires a complete, self-contained `reentryPrompt`. An

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -15,6 +15,7 @@ Create a new context lazily when another experiment develops domain-specific lan
 
 ## Current Layout
 
+- `docs/scheduler/CONTEXT.md` — Pi scheduler wake extension language and Queue boundary
 - `docs/subagents/CONTEXT.md` — Pi subagent extension language
 - `docs/subagents/docs/adr/` — future context-specific ADRs
 - `docs/adr/` — future repository-wide ADRs

--- a/docs/scheduler/CONTEXT.md
+++ b/docs/scheduler/CONTEXT.md
@@ -1,0 +1,68 @@
+# Pi Scheduler
+
+Language and boundaries for the opt-in Pi extension that submits
+fire-and-forget scheduler wakes through the existing global `bq` wrapper.
+
+## Language
+
+**Scheduler extension**:
+The Pi-facing adapter that owns scheduler submission, the live session callback
+endpoint, and visible scheduler wake delivery. It delegates timing and durable
+execution to `bq` and OMQueue.
+_Avoid_: OMQueue client, Queue administrator, watcher, workflow engine
+
+**Scheduler submission**:
+One immediate `bq` acceptance request containing timing options, a required
+reentry prompt, and an optional payload. The extension returns when `bq` exits;
+it does not wait for the queued payload.
+_Avoid_: Job completion, synchronous scheduler run, Queue watch
+
+**Reentry prompt**:
+The required self-contained instruction carried by every scheduler submission
+and repeated in its wake. It preserves the deferred context, checks,
+constraints, and next decision after delay or context compaction.
+_Avoid_: Label, short notification, implicit conversation memory
+
+**Payload**:
+The optional executable, literal argument vector, and working directory run by
+the callback runner before waking Pi. Omitting it creates a heartbeat-only wake.
+Payloads are never shell command strings.
+_Avoid_: Shell script text, Queue Job definition
+
+**Callback runner**:
+The scheduler-owned executable submitted as the actual `bq` payload. It runs the
+optional payload, forwards its original streams for OMQueue capture, keeps
+bounded previews, sends one callback when mechanically possible, and preserves
+the payload exit or signal outcome.
+_Avoid_: Queue worker, completion watcher
+
+**Callback endpoint**:
+The private, versioned Unix-socket listener owned by one live Pi session. It
+accepts only bounded frames correlated with that session's capability and known
+submissions, and it is removed on session shutdown.
+_Avoid_: Durable mailbox, network service, Queue event endpoint
+
+**Scheduler wake**:
+The visible follow-up message injected into the owning Pi conversation after a
+callback. It contains the complete reentry prompt, the callback runner's
+mechanical payload outcome, and bounded stream previews. It is not an official
+terminal OMQueue Job state.
+_Avoid_: Queue completion event, watcher result, durable notification
+
+## Boundary Contract
+
+- `bq` owns timing syntax, timing validation, durable Job or Schedule
+  acceptance, and OMQueue integration.
+- OMQueue remains opaque to the scheduler extension.
+- A scheduler submission invokes `bq` directly with a literal argument vector
+  and returns its bounded stdout, stderr, and exit status without waiting for
+  Queue completion.
+- The extension never calls `omqueue watch`, polls Job state, reads the Queue
+  database, or exposes cancellation, retry, history, output retrieval, or other
+  Queue administration.
+- Raw `bq` invocation or inspection requested by the user remains ordinary bash
+  work, not a scheduler submission.
+- Scheduler wakes are best effort and session-scoped. Closing Pi, host loss,
+  forced runner termination, or failure before the runner starts can prevent a
+  wake. Durable schedules and payloads may continue after the owning Pi session
+  closes.

--- a/docs/scheduler/CONTEXT.md
+++ b/docs/scheduler/CONTEXT.md
@@ -56,7 +56,9 @@ _Avoid_: Queue completion event, watcher result, durable notification
 - OMQueue remains opaque to the scheduler extension.
 - A scheduler submission invokes `bq` directly with a literal argument vector
   and returns its bounded stdout, stderr, and exit status without waiting for
-  Queue completion.
+  Queue completion. A zero exit confirms acceptance; every other result leaves
+  acceptance unknown because durable work may already have been created and
+  must not be retried blindly.
 - The extension never calls `omqueue watch`, polls Job state, reads the Queue
   database, or exposes cancellation, retry, history, output retrieval, or other
   Queue administration.

--- a/extensions/scheduler/callback-runner.mjs
+++ b/extensions/scheduler/callback-runner.mjs
@@ -1,0 +1,315 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { createConnection } from "node:net";
+
+const PROTOCOL_VERSION = 1;
+const MAX_ACK_BYTES = 1_024;
+const CALLBACK_TIMEOUT_MS = 2_000;
+const MAX_REENTRY_PROMPT_BYTES = 8_000;
+const MAX_PREVIEW_BYTES = 4_000;
+const MAX_START_ERROR_BYTES = 2_000;
+const MAX_PAYLOAD_ARGUMENTS = 128;
+const MAX_ARGUMENT_BYTES = 8_000;
+const MAX_TOTAL_ARGUMENT_BYTES = 64_000;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const CAPABILITY_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+const PAYLOAD_ENVIRONMENT_KEYS = [
+  "HOME",
+  "LANG",
+  "LC_ALL",
+  "LC_CTYPE",
+  "LOGNAME",
+  "PATH",
+  "PROJECTS_DIR",
+  "SHELL",
+  "TMPDIR",
+  "TZ",
+  "USER",
+];
+
+function fail(message) {
+  process.stderr.write(`scheduler callback runner: ${message}\n`);
+  process.exitCode = 2;
+}
+
+function parseArguments(arguments_) {
+  const values = {};
+  let index = 0;
+  for (const option of ["--socket", "--capability", "--submission", "--prompt-base64"]) {
+    if (arguments_[index] !== option || index + 1 >= arguments_.length) {
+      throw new Error(`expected ${option}`);
+    }
+    values[option.slice(2)] = arguments_[index + 1];
+    index += 2;
+  }
+
+  let payload;
+  if (index < arguments_.length) {
+    if (arguments_[index] !== "--" || index + 1 >= arguments_.length) {
+      throw new Error("unexpected callback runner arguments");
+    }
+    payload = {
+      executable: arguments_[index + 1],
+      args: arguments_.slice(index + 2),
+    };
+  }
+
+  if (!values.socket || !values.capability || !values.submission) {
+    throw new Error("callback endpoint, capability, and submission are required");
+  }
+  if (!values.socket.startsWith("/") || Buffer.byteLength(values.socket, "utf8") > 1_024) {
+    throw new Error("callback endpoint path is invalid");
+  }
+  if (!CAPABILITY_PATTERN.test(values.capability) || !UUID_PATTERN.test(values.submission)) {
+    throw new Error("callback capability or submission identity is invalid");
+  }
+  if (payload) {
+    if (!payload.executable.trim() || Buffer.byteLength(payload.executable, "utf8") > MAX_ARGUMENT_BYTES) {
+      throw new Error("payload executable is invalid");
+    }
+    if (payload.args.length > MAX_PAYLOAD_ARGUMENTS
+      || payload.args.some((argument) => Buffer.byteLength(argument, "utf8") > MAX_ARGUMENT_BYTES)
+      || payload.args.reduce((total, argument) => total + Buffer.byteLength(argument, "utf8"), 0) > MAX_TOTAL_ARGUMENT_BYTES) {
+      throw new Error("payload argument vector exceeds its limit");
+    }
+  }
+  if (!/^[A-Za-z0-9_-]+$/.test(values["prompt-base64"] ?? "")) {
+    throw new Error("reentry prompt encoding is invalid");
+  }
+  const reentryPrompt = Buffer.from(values["prompt-base64"], "base64url").toString("utf8");
+  if (Buffer.from(reentryPrompt, "utf8").toString("base64url") !== values["prompt-base64"]
+    || !reentryPrompt.trim()
+    || Buffer.byteLength(reentryPrompt, "utf8") > MAX_REENTRY_PROMPT_BYTES) {
+    throw new Error("reentry prompt is invalid");
+  }
+
+  return {
+    socketPath: values.socket,
+    capability: values.capability,
+    submissionId: values.submission,
+    reentryPrompt,
+    payload,
+  };
+}
+
+function decodeWithin(buffer, maximumBytes) {
+  let text = buffer.toString("utf8");
+  while (Buffer.byteLength(text, "utf8") > maximumBytes && text.length > 0) {
+    const last = text.charCodeAt(text.length - 1);
+    const remove = last >= 0xdc00 && last <= 0xdfff && text.length > 1 ? 2 : 1;
+    text = text.slice(0, -remove);
+  }
+  return text;
+}
+
+class BoundedPreview {
+  #chunks = [];
+  #bytes = 0;
+  #seenBytes = 0;
+
+  append(chunk) {
+    this.#seenBytes += chunk.length;
+    const remaining = MAX_PREVIEW_BYTES - this.#bytes;
+    if (remaining <= 0) return;
+    const retained = chunk.subarray(0, remaining);
+    this.#chunks.push(retained);
+    this.#bytes += retained.length;
+  }
+
+  value() {
+    return {
+      preview: decodeWithin(Buffer.concat(this.#chunks, this.#bytes), MAX_PREVIEW_BYTES),
+      truncated: this.#seenBytes > MAX_PREVIEW_BYTES,
+    };
+  }
+}
+
+class WriteTracker {
+  #pending = 0;
+  #waiters = [];
+
+  write(source, destination, chunk) {
+    this.#pending++;
+    const writable = destination.write(chunk, () => {
+      this.#pending--;
+      if (this.#pending === 0) {
+        for (const resolve of this.#waiters.splice(0)) resolve();
+      }
+    });
+    if (!writable) {
+      source.pause();
+      destination.once("drain", () => source.resume());
+    }
+  }
+
+  wait() {
+    if (this.#pending === 0) return Promise.resolve();
+    return new Promise((resolve) => this.#waiters.push(resolve));
+  }
+}
+
+function selectedPayloadEnvironment(source) {
+  const environment = {};
+  for (const key of PAYLOAD_ENVIRONMENT_KEYS) {
+    if (source[key] !== undefined) environment[key] = source[key];
+  }
+  return environment;
+}
+
+function boundedError(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  const bytes = Buffer.from(message, "utf8");
+  return decodeWithin(bytes.subarray(0, MAX_START_ERROR_BYTES), MAX_START_ERROR_BYTES);
+}
+
+function runPayload(payload) {
+  return new Promise((resolve) => {
+    const stdout = new BoundedPreview();
+    const stderr = new BoundedPreview();
+    const stdoutWrites = new WriteTracker();
+    const stderrWrites = new WriteTracker();
+    let child;
+    let settled = false;
+    const finish = (outcome) => {
+      if (settled) return;
+      settled = true;
+      resolve({ outcome, stdout: stdout.value(), stderr: stderr.value() });
+    };
+    const startFailed = (error) => {
+      const message = boundedError(error);
+      process.stderr.write(`scheduler callback runner: payload start failed: ${message}\n`);
+      finish({ kind: "start_error", message });
+    };
+
+    try {
+      child = spawn(payload.executable, payload.args, {
+        cwd: process.cwd(),
+        env: selectedPayloadEnvironment(process.env),
+        shell: false,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (error) {
+      startFailed(error);
+      return;
+    }
+
+    child.stdout.on("data", (chunk) => {
+      stdout.append(chunk);
+      stdoutWrites.write(child.stdout, process.stdout, chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr.append(chunk);
+      stderrWrites.write(child.stderr, process.stderr, chunk);
+    });
+    child.once("error", startFailed);
+    child.once("close", async (code, signal) => {
+      await Promise.all([stdoutWrites.wait(), stderrWrites.wait()]);
+      if (signal) finish({ kind: "signal", signal });
+      else finish({ kind: "exit", code: code ?? 1 });
+    });
+  });
+}
+
+function sendCallback(socketPath, frame) {
+  const serialized = `${JSON.stringify(frame)}\n`;
+  return new Promise((resolve, reject) => {
+    const socket = createConnection(socketPath);
+    let response = Buffer.alloc(0);
+    let settled = false;
+    const finish = (error) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      if (error) reject(error);
+      else resolve();
+    };
+
+    socket.setTimeout(CALLBACK_TIMEOUT_MS, () => finish(new Error("callback timed out")));
+    socket.once("connect", () => socket.end(serialized, "utf8"));
+    socket.on("data", (chunk) => {
+      if (response.length + chunk.length > MAX_ACK_BYTES) {
+        finish(new Error("callback acknowledgement exceeded its limit"));
+        return;
+      }
+      response = Buffer.concat([response, chunk]);
+    });
+    socket.once("end", () => {
+      const lines = response.toString("utf8").split("\n").filter((line) => line.length > 0);
+      if (lines.length !== 1) {
+        finish(new Error("callback acknowledgement was malformed"));
+        return;
+      }
+      let acknowledgement;
+      try {
+        acknowledgement = JSON.parse(lines[0]);
+      } catch {
+        finish(new Error("callback acknowledgement was malformed"));
+        return;
+      }
+      const keys = acknowledgement && typeof acknowledgement === "object"
+        ? Object.keys(acknowledgement).sort()
+        : [];
+      if (keys.join(",") !== "ok,version"
+        || acknowledgement.version !== PROTOCOL_VERSION
+        || acknowledgement.ok !== true) {
+        finish(new Error("callback was rejected"));
+        return;
+      }
+      finish();
+    });
+    socket.once("error", (error) => finish(error));
+  });
+}
+
+async function main() {
+  let request;
+  try {
+    request = parseArguments(process.argv.slice(2));
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
+    return;
+  }
+
+  const result = request.payload
+    ? await runPayload(request.payload)
+    : {
+        outcome: { kind: "heartbeat" },
+        stdout: { preview: "", truncated: false },
+        stderr: { preview: "", truncated: false },
+      };
+  const frame = {
+    version: PROTOCOL_VERSION,
+    capability: request.capability,
+    submissionId: request.submissionId,
+    wakeId: randomUUID(),
+    reentryPrompt: request.reentryPrompt,
+    outcome: result.outcome,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+
+  let callbackFailed = false;
+  try {
+    await sendCallback(request.socketPath, frame);
+  } catch (error) {
+    callbackFailed = true;
+    process.stderr.write(`scheduler callback runner: callback unavailable: ${error instanceof Error ? error.message : String(error)}\n`);
+  }
+
+  if (result.outcome.kind === "exit") process.exitCode = result.outcome.code;
+  else if (result.outcome.kind === "start_error") process.exitCode = 127;
+  else if (result.outcome.kind === "signal") {
+    try {
+      process.kill(process.pid, result.outcome.signal);
+    } catch (error) {
+      process.stderr.write(`scheduler callback runner: cannot preserve payload signal ${result.outcome.signal}: ${boundedError(error)}\n`);
+      process.exitCode = 1;
+    }
+  } else if (callbackFailed) {
+    process.exitCode = 1;
+  }
+}
+
+await main();

--- a/extensions/scheduler/callback-runner.mjs
+++ b/extensions/scheduler/callback-runner.mjs
@@ -302,11 +302,15 @@ async function main() {
     process.stderr.write(`scheduler callback runner: callback unavailable: ${error instanceof Error ? error.message : String(error)}\n`);
   }
 
-  if (result.outcome.kind === "exit") {
-    process.exitCode = result.outcome.code === 0 && callbackFailed ? 1 : result.outcome.code;
-  } else if (result.outcome.kind === "start_error") process.exitCode = 127;
+  if (result.outcome.kind === "exit") process.exitCode = result.outcome.code;
+  else if (result.outcome.kind === "start_error") process.exitCode = 127;
   else if (result.outcome.kind === "signal") {
     try {
+      if (result.outcome.signal !== "SIGKILL" && result.outcome.signal !== "SIGSTOP") {
+        const restoreDefaultDisposition = () => {};
+        process.on(result.outcome.signal, restoreDefaultDisposition);
+        process.off(result.outcome.signal, restoreDefaultDisposition);
+      }
       process.kill(process.pid, result.outcome.signal);
     } catch (error) {
       process.stderr.write(`scheduler callback runner: cannot preserve payload signal ${result.outcome.signal}: ${boundedError(error)}\n`);

--- a/extensions/scheduler/callback-runner.mjs
+++ b/extensions/scheduler/callback-runner.mjs
@@ -6,6 +6,7 @@ import { createConnection } from "node:net";
 
 const PROTOCOL_VERSION = 1;
 const MAX_ACK_BYTES = 1_024;
+const MAX_CALLBACK_FRAME_BYTES = 128_000;
 const CALLBACK_TIMEOUT_MS = 2_000;
 const MAX_REENTRY_PROMPT_BYTES = 8_000;
 const MAX_PREVIEW_BYTES = 4_000;
@@ -214,6 +215,9 @@ function runPayload(payload) {
 
 function sendCallback(socketPath, frame) {
   const serialized = `${JSON.stringify(frame)}\n`;
+  if (Buffer.byteLength(serialized, "utf8") > MAX_CALLBACK_FRAME_BYTES) {
+    return Promise.reject(new Error("callback frame exceeded its limit"));
+  }
   return new Promise((resolve, reject) => {
     const socket = createConnection(socketPath);
     let response = Buffer.alloc(0);
@@ -298,8 +302,9 @@ async function main() {
     process.stderr.write(`scheduler callback runner: callback unavailable: ${error instanceof Error ? error.message : String(error)}\n`);
   }
 
-  if (result.outcome.kind === "exit") process.exitCode = result.outcome.code;
-  else if (result.outcome.kind === "start_error") process.exitCode = 127;
+  if (result.outcome.kind === "exit") {
+    process.exitCode = result.outcome.code === 0 && callbackFailed ? 1 : result.outcome.code;
+  } else if (result.outcome.kind === "start_error") process.exitCode = 127;
   else if (result.outcome.kind === "signal") {
     try {
       process.kill(process.pid, result.outcome.signal);

--- a/extensions/scheduler/index.test.ts
+++ b/extensions/scheduler/index.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it } from "vitest";
-import { registerSchedulerExtension } from "./index.ts";
+import { formatSchedulerSubmission, registerSchedulerExtension } from "./index.ts";
 import type { BqInvocation } from "./scheduler.ts";
 
 interface RegisteredTool {
@@ -39,6 +39,27 @@ async function runQueuedInvocation(invocation: BqInvocation): Promise<void> {
 }
 
 describe("scheduler extension", () => {
+  it("warns that nonzero bq completion may have partially accepted durable work", () => {
+    const text = formatSchedulerSubmission({
+      acceptance: "unknown",
+      submissionId: "submission-1",
+      bq: {
+        code: 2,
+        signal: null,
+        stdout: "bq: scheduled 1/4 at=... schedule-1\n",
+        stderr: "later schedule failed\n",
+        stdoutTruncated: false,
+        stderrTruncated: false,
+        cancelled: false,
+      },
+    });
+
+    expect(text).toContain("acceptance is unknown");
+    expect(text).toContain("durable work may already have been created");
+    expect(text).toContain("Do not blindly retry");
+    expect(text).not.toContain("was not accepted");
+  });
+
   it("submits through the Pi tool and injects the callback as a visible follow-up wake", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "ompi-scheduler-index-"));
     const tools: RegisteredTool[] = [];

--- a/extensions/scheduler/index.test.ts
+++ b/extensions/scheduler/index.test.ts
@@ -1,0 +1,113 @@
+import { spawn } from "node:child_process";
+import { lstat, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { registerSchedulerExtension } from "./index.ts";
+import type { BqInvocation } from "./scheduler.ts";
+
+interface RegisteredTool {
+  name: string;
+  description: string;
+  promptSnippet?: string;
+  promptGuidelines?: string[];
+  execute(
+    id: string,
+    params: Record<string, unknown>,
+    signal: AbortSignal | undefined,
+    onUpdate: undefined,
+    ctx: ExtensionContext,
+  ): Promise<{ content: Array<{ type: string; text: string }>; details?: unknown }>;
+}
+
+async function runQueuedInvocation(invocation: BqInvocation): Promise<void> {
+  const separator = invocation.args.indexOf("--");
+  await new Promise<void>((resolveRun, reject) => {
+    const child = spawn(invocation.args[separator + 1], invocation.args.slice(separator + 2), {
+      cwd: invocation.args[invocation.args.indexOf("--cwd") + 1],
+      env: invocation.env,
+      shell: false,
+      stdio: "ignore",
+    });
+    child.once("error", reject);
+    child.once("close", (code, signal) => {
+      if (code === 0 && signal === null) resolveRun();
+      else reject(new Error(`callback runner failed: code=${code}, signal=${signal}`));
+    });
+  });
+}
+
+describe("scheduler extension", () => {
+  it("submits through the Pi tool and injects the callback as a visible follow-up wake", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "ompi-scheduler-index-"));
+    const tools: RegisteredTool[] = [];
+    const handlers = new Map<string, (...args: unknown[]) => unknown>();
+    const messages: Array<{ message: Record<string, unknown>; options: Record<string, unknown> }> = [];
+    let invocation: BqInvocation | undefined;
+    const pi = {
+      registerTool: (tool: RegisteredTool) => tools.push(tool),
+      on: (event: string, handler: (...args: unknown[]) => unknown) => handlers.set(event, handler),
+      sendMessage: (message: Record<string, unknown>, options: Record<string, unknown>) => {
+        messages.push({ message, options });
+      },
+    } as unknown as ExtensionAPI;
+    const ctx = { cwd } as ExtensionContext;
+
+    registerSchedulerExtension(pi, {
+      runBq: async (candidate) => {
+        invocation = candidate;
+        return {
+          code: 0,
+          signal: null,
+          stdout: "bq: accepted Job tool-1 (queued)\n",
+          stderr: "warning\n",
+          stdoutTruncated: false,
+          stderrTruncated: false,
+          cancelled: false,
+        };
+      },
+    });
+
+    try {
+      expect(tools.map((tool) => tool.name)).toEqual(["scheduler_submit"]);
+      const discovery = [
+        tools[0].description,
+        tools[0].promptSnippet ?? "",
+        ...(tools[0].promptGuidelines ?? []),
+      ].join(" ");
+      for (const term of ["cron", "scheduler", "heartbeat", "reminder", "delayed command", "deferred recheck"]) {
+        expect(discovery).toContain(term);
+      }
+      expect(discovery).toContain("complete self-contained reentryPrompt");
+      expect(discovery).toContain("never wait, sleep, poll");
+      expect(discovery).toContain("ordinary bash");
+      await handlers.get("session_start")?.({}, ctx);
+      const result = await tools[0].execute("call-1", {
+        reentryPrompt: "Recheck the service health, compare it with the incident criteria, and report the next action.",
+      }, undefined, undefined, ctx);
+      if (!invocation) throw new Error("bq invocation was not captured");
+      const socketPath = invocation.args[invocation.args.indexOf("--socket") + 1];
+
+      expect(result.content[0].text).toContain("exit code: 0");
+      expect(result.content[0].text).toContain("bq: accepted Job tool-1 (queued)\n");
+      expect(result.content[0].text).toContain("warning\n");
+      expect(result.content[0].text).toContain("Never wait, poll, or watch Queue completion");
+      await runQueuedInvocation(invocation);
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0].options).toEqual({ deliverAs: "followUp", triggerTurn: true });
+      expect(messages[0].message).toMatchObject({ customType: "scheduler-wake", display: true });
+      expect(messages[0].message.content).toContain("[SCHEDULER WAKE]");
+      expect(messages[0].message.content).toContain(
+        "Recheck the service health, compare it with the incident criteria, and report the next action.",
+      );
+      expect(messages[0].message.content).toContain("not an official OMQueue Job state");
+
+      await handlers.get("session_shutdown")?.({}, ctx);
+      await expect(lstat(socketPath)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/extensions/scheduler/index.ts
+++ b/extensions/scheduler/index.ts
@@ -93,16 +93,17 @@ function streamSection(name: "stdout" | "stderr", value: string, truncated: bool
 }
 
 export function formatSchedulerSubmission(result: SchedulerSubmissionResult): string {
-  const heading = result.accepted
+  const confirmed = result.acceptance === "confirmed";
+  const heading = confirmed
     ? `Scheduler submission accepted by bq (${bqStatus(result.bq)}).`
-    : `Scheduler submission was not accepted by bq (${bqStatus(result.bq)}).`;
+    : `Scheduler submission acceptance is unknown (${bqStatus(result.bq)}).`;
   return [
     heading,
     streamSection("stdout", result.bq.stdout, result.bq.stdoutTruncated),
     streamSection("stderr", result.bq.stderr, result.bq.stderrTruncated),
-    result.accepted
+    confirmed
       ? "Never wait, poll, or watch Queue completion. Continue only independent work or end this response; the scheduler wake will arrive later if the live owning session is reachable."
-      : "No acceptance is claimed. Correct the reported submission problem before trying again.",
+      : "bq did not confirm complete acceptance, but durable work may already have been created. Do not blindly retry because that could duplicate work; inspect the returned diagnostics and use explicitly requested raw bq or OMQueue administration when reconciliation is needed.",
   ].join("\n\n");
 }
 

--- a/extensions/scheduler/index.ts
+++ b/extensions/scheduler/index.ts
@@ -1,0 +1,162 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type, type Static } from "typebox";
+import {
+  SchedulerSession,
+  type BqInvocation,
+  type BqProcessResult,
+  type SchedulerPayloadOutcome,
+  type SchedulerStreamPreview,
+  type SchedulerSubmissionResult,
+  type SchedulerWake,
+} from "./scheduler.ts";
+
+const MAX_REENTRY_PROMPT_CHARACTERS = 8_000;
+const MAX_ARGUMENT_CHARACTERS = 8_000;
+const MAX_PAYLOAD_ARGUMENTS = 128;
+const MAX_TIMING_CHARACTERS = 1_024;
+
+const TimingValue = Type.String({ minLength: 1, maxLength: MAX_TIMING_CHARACTERS });
+const TimingSchema = Type.Object({
+  in: Type.Optional(TimingValue),
+  at: Type.Optional(TimingValue),
+  cron: Type.Optional(TimingValue),
+  tz: Type.Optional(TimingValue),
+  every: Type.Optional(TimingValue),
+  count: Type.Optional(Type.Integer()),
+}, { additionalProperties: false });
+const PayloadSchema = Type.Object({
+  executable: Type.String({ minLength: 1, maxLength: MAX_ARGUMENT_CHARACTERS }),
+  args: Type.Optional(Type.Array(
+    Type.String({ maxLength: MAX_ARGUMENT_CHARACTERS }),
+    { maxItems: MAX_PAYLOAD_ARGUMENTS },
+  )),
+  cwd: Type.Optional(Type.String({ minLength: 1, maxLength: MAX_ARGUMENT_CHARACTERS })),
+}, { additionalProperties: false });
+const SubmitSchema = Type.Object({
+  reentryPrompt: Type.String({
+    minLength: 1,
+    maxLength: MAX_REENTRY_PROMPT_CHARACTERS,
+    description: "Required self-contained prompt that explains the deferred context, completed event, checks to perform, constraints, and next decision.",
+  }),
+  timing: Type.Optional(TimingSchema),
+  payload: Type.Optional(PayloadSchema),
+}, { additionalProperties: false });
+
+type SubmitParams = Static<typeof SubmitSchema>;
+
+export interface SchedulerExtensionOptions {
+  runBq?: (invocation: BqInvocation) => Promise<BqProcessResult>;
+}
+
+function outcomeText(outcome: SchedulerPayloadOutcome): string {
+  switch (outcome.kind) {
+    case "heartbeat":
+      return "heartbeat delivered (no payload command)";
+    case "exit":
+      return `payload exited with code ${outcome.code}`;
+    case "signal":
+      return `payload terminated by signal ${outcome.signal}`;
+    case "start_error":
+      return `payload could not start: ${outcome.message}`;
+  }
+}
+
+function previewText(name: "stdout" | "stderr", value: SchedulerStreamPreview): string | undefined {
+  if (!value.preview && !value.truncated) return undefined;
+  const bytes = Buffer.byteLength(value.preview, "utf8");
+  const notice = value.truncated ? ` (${bytes.toLocaleString("en-US")} byte preview; truncated)` : "";
+  return `${name}${notice}:\n${value.preview}`;
+}
+
+export function formatSchedulerWake(wake: SchedulerWake): string {
+  const parts = [
+    "[SCHEDULER WAKE]",
+    `Reentry prompt (complete):\n${wake.reentryPrompt}`,
+    `Mechanical payload outcome (not an official OMQueue Job state): ${outcomeText(wake.outcome)}`,
+  ];
+  const stdout = previewText("stdout", wake.stdout);
+  const stderr = previewText("stderr", wake.stderr);
+  if (stdout) parts.push(stdout);
+  if (stderr) parts.push(stderr);
+  return parts.join("\n\n");
+}
+
+function bqStatus(result: BqProcessResult): string {
+  if (result.cancelled) return "cancelled before bq finished reporting acceptance";
+  if (result.code !== null) return `exit code: ${result.code}`;
+  return `signal: ${result.signal ?? "unknown"}`;
+}
+
+function streamSection(name: "stdout" | "stderr", value: string, truncated: boolean): string {
+  const notice = truncated ? " (truncated to the scheduler adapter limit)" : "";
+  return `${name}${notice}:\n${value}`;
+}
+
+export function formatSchedulerSubmission(result: SchedulerSubmissionResult): string {
+  const heading = result.accepted
+    ? `Scheduler submission accepted by bq (${bqStatus(result.bq)}).`
+    : `Scheduler submission was not accepted by bq (${bqStatus(result.bq)}).`;
+  return [
+    heading,
+    streamSection("stdout", result.bq.stdout, result.bq.stdoutTruncated),
+    streamSection("stderr", result.bq.stderr, result.bq.stderrTruncated),
+    result.accepted
+      ? "Never wait, poll, or watch Queue completion. Continue only independent work or end this response; the scheduler wake will arrive later if the live owning session is reachable."
+      : "No acceptance is claimed. Correct the reported submission problem before trying again.",
+  ].join("\n\n");
+}
+
+export function registerSchedulerExtension(
+  pi: ExtensionAPI,
+  options: SchedulerExtensionOptions = {},
+): void {
+  let session: SchedulerSession | undefined;
+
+  pi.registerTool({
+    name: "scheduler_submit",
+    label: "Submit Scheduler Wake",
+    description: "Submit an immediate, delayed, absolute-time, finite-repeat, or cron scheduler wake through the existing global bq wrapper. Use for scheduler, cron, heartbeat, reminder, delayed command, or deferred recheck requests. Returns after bounded bq acceptance output and never waits for Queue completion. A complete reentryPrompt is required; an optional executable and literal argument vector run without a shell before the wake. Raw bq invocation or inspection remains ordinary bash work.",
+    promptSnippet: "Submit a fire-and-forget scheduler, cron, heartbeat, reminder, delayed command, or deferred recheck wake",
+    promptGuidelines: [
+      "Use scheduler_submit only for fire-and-forget scheduler wakes; always provide a complete self-contained reentryPrompt that preserves deferred context, required checks, constraints, and the next decision.",
+      "After scheduler_submit reports bq acceptance, never wait, sleep, poll, inspect OMQueue, or watch Queue completion; continue only independent work or end the response so a later scheduler wake can be delivered.",
+      "When the user explicitly asks to invoke or inspect raw bq behavior, use ordinary bash instead of scheduler_submit.",
+    ],
+    parameters: SubmitSchema,
+    async execute(_toolCallId, params: SubmitParams, signal, _onUpdate, ctx) {
+      if (!session) throw new Error("Scheduler callback endpoint is unavailable; this Pi session has not started.");
+      const result = await session.submit(params, ctx.cwd, signal);
+      return {
+        content: [{ type: "text", text: formatSchedulerSubmission(result) }],
+        details: result,
+      };
+    },
+  });
+
+  pi.on("session_start", async () => {
+    const previous = session;
+    session = undefined;
+    await previous?.close();
+    session = await SchedulerSession.start({
+      runBq: options.runBq,
+      onWake: (wake) => {
+        pi.sendMessage({
+          customType: "scheduler-wake",
+          content: formatSchedulerWake(wake),
+          display: true,
+          details: wake,
+        }, { deliverAs: "followUp", triggerTurn: true });
+      },
+    });
+  });
+
+  pi.on("session_shutdown", async () => {
+    const closing = session;
+    session = undefined;
+    await closing?.close();
+  });
+}
+
+export default function schedulerExtension(pi: ExtensionAPI): void {
+  registerSchedulerExtension(pi);
+}

--- a/extensions/scheduler/process.test.ts
+++ b/extensions/scheduler/process.test.ts
@@ -1,0 +1,45 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { runBqProcess } from "./process.ts";
+
+function invocation(script: string) {
+  return {
+    command: process.execPath,
+    args: ["--input-type=module", "--eval", script],
+    cwd: process.cwd(),
+    env: { PATH: process.env.PATH },
+  };
+}
+
+describe("bq process adapter", () => {
+  it("captures bounded unmodified acceptance streams and exit status without a shell", async () => {
+    const result = await runBqProcess(invocation(
+      "process.stdout.write('accepted\\n' + 'o'.repeat(20000)); process.stderr.write('e'.repeat(10000)); process.exitCode = 7;",
+    ));
+
+    expect(result).toEqual({
+      code: 7,
+      signal: null,
+      stdout: `accepted\n${"o".repeat(15_991)}`,
+      stderr: "e".repeat(8_000),
+      stdoutTruncated: true,
+      stderrTruncated: true,
+      cancelled: false,
+    });
+  });
+
+  it("keeps multibyte bq output within the byte limit", async () => {
+    const result = await runBqProcess(invocation("process.stdout.write('€'.repeat(6000));"));
+
+    expect(result.stdoutTruncated).toBe(true);
+    expect(Buffer.byteLength(result.stdout, "utf8")).toBeLessThanOrEqual(16_000);
+  });
+
+  it("reports when the bq executable cannot start", async () => {
+    await expect(runBqProcess({
+      ...invocation(""),
+      command: join(tmpdir(), `missing-bq-${process.pid}`),
+    })).rejects.toThrow("Failed to start bq");
+  });
+});

--- a/extensions/scheduler/process.ts
+++ b/extensions/scheduler/process.ts
@@ -1,0 +1,144 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import type { BqInvocation, BqProcessResult } from "./scheduler.ts";
+
+const MAX_BQ_STDOUT_BYTES = 16_000;
+const MAX_BQ_STDERR_BYTES = 8_000;
+const FORCE_KILL_DELAY_MS = 500;
+
+function decodeWithin(buffer: Buffer, maximumBytes: number): string {
+  let text = buffer.toString("utf8");
+  while (Buffer.byteLength(text, "utf8") > maximumBytes && text.length > 0) {
+    const last = text.charCodeAt(text.length - 1);
+    const remove = last >= 0xdc00 && last <= 0xdfff && text.length > 1 ? 2 : 1;
+    text = text.slice(0, -remove);
+  }
+  return text;
+}
+
+class BoundedCapture {
+  private readonly chunks: Buffer[] = [];
+  private bytes = 0;
+  private seenBytes = 0;
+
+  constructor(private readonly limit: number) {}
+
+  append(chunk: Buffer): void {
+    this.seenBytes += chunk.length;
+    const remaining = this.limit - this.bytes;
+    if (remaining <= 0) return;
+    const retained = chunk.subarray(0, remaining);
+    this.chunks.push(retained);
+    this.bytes += retained.length;
+  }
+
+  get truncated(): boolean {
+    return this.seenBytes > this.limit;
+  }
+
+  text(): string {
+    return decodeWithin(Buffer.concat(this.chunks, this.bytes), this.limit);
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function killProcessGroup(child: ChildProcess, signal: NodeJS.Signals): void {
+  if (child.pid && process.platform !== "win32") {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch {
+      // Fall back when the process group has already exited.
+    }
+  }
+  try {
+    child.kill(signal);
+  } catch {
+    // The direct child has already exited.
+  }
+}
+
+export function runBqProcess(invocation: BqInvocation): Promise<BqProcessResult> {
+  if (invocation.signal?.aborted) {
+    return Promise.resolve({
+      code: null,
+      signal: null,
+      stdout: "",
+      stderr: "",
+      stdoutTruncated: false,
+      stderrTruncated: false,
+      cancelled: true,
+    });
+  }
+
+  return new Promise((resolveRun, reject) => {
+    const stdout = new BoundedCapture(MAX_BQ_STDOUT_BYTES);
+    const stderr = new BoundedCapture(MAX_BQ_STDERR_BYTES);
+    let child: ChildProcess;
+    let startupError: Error | undefined;
+    let cancelled = false;
+    let forceKill: NodeJS.Timeout | undefined;
+    let settled = false;
+
+    const abort = () => {
+      if (settled || cancelled) return;
+      cancelled = true;
+      killProcessGroup(child, "SIGTERM");
+      forceKill = setTimeout(() => killProcessGroup(child, "SIGKILL"), FORCE_KILL_DELAY_MS);
+    };
+    const cleanup = () => {
+      invocation.signal?.removeEventListener("abort", abort);
+      if (forceKill) clearTimeout(forceKill);
+    };
+
+    try {
+      child = spawn(invocation.command, invocation.args, {
+        cwd: invocation.cwd,
+        env: invocation.env,
+        shell: false,
+        detached: process.platform !== "win32",
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (error) {
+      reject(new Error(`Failed to start bq: ${errorMessage(error)}`));
+      return;
+    }
+
+    invocation.signal?.addEventListener("abort", abort, { once: true });
+    child.stdout?.on("data", (chunk: Buffer) => stdout.append(chunk));
+    child.stderr?.on("data", (chunk: Buffer) => stderr.append(chunk));
+    child.once("error", (error) => {
+      startupError = error;
+    });
+    child.once("exit", () => {
+      killProcessGroup(child, "SIGTERM");
+      forceKill ??= setTimeout(
+        () => killProcessGroup(child, "SIGKILL"),
+        FORCE_KILL_DELAY_MS,
+      );
+    });
+    child.once("close", (code, signal) => {
+      if (settled) return;
+      settled = true;
+      killProcessGroup(child, "SIGKILL");
+      cleanup();
+      if (startupError) {
+        reject(new Error(`Failed to start bq: ${startupError.message}`));
+        return;
+      }
+      resolveRun({
+        code,
+        signal,
+        stdout: stdout.text(),
+        stderr: stderr.text(),
+        stdoutTruncated: stdout.truncated,
+        stderrTruncated: stderr.truncated,
+        cancelled,
+      });
+    });
+
+    if (invocation.signal?.aborted) abort();
+  });
+}

--- a/extensions/scheduler/scheduler.test.ts
+++ b/extensions/scheduler/scheduler.test.ts
@@ -1,0 +1,676 @@
+import { spawn } from "node:child_process";
+import { lstat, mkdtemp, rm } from "node:fs/promises";
+import { createConnection } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  SchedulerSession,
+  type BqInvocation,
+  type BqProcessResult,
+  type SchedulerWake,
+} from "./scheduler.ts";
+
+const temporaryDirectories: string[] = [];
+
+async function temporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "ompi-scheduler-test-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function valueAfter(invocation: BqInvocation, option: string): string {
+  const index = invocation.args.indexOf(option);
+  const value = invocation.args[index + 1];
+  if (index < 0 || value === undefined) throw new Error(`Missing invocation option: ${option}`);
+  return value;
+}
+
+async function sendRawCallback(socketPath: string, frame: unknown): Promise<string> {
+  return new Promise((resolveSend, reject) => {
+    const socket = createConnection(socketPath);
+    let response = "";
+    socket.setEncoding("utf8");
+    socket.once("connect", () => socket.end(`${JSON.stringify(frame)}\n`, "utf8"));
+    socket.on("data", (chunk: string) => { response += chunk; });
+    socket.once("end", () => resolveSend(response));
+    socket.once("error", reject);
+  });
+}
+
+async function runQueuedInvocation(invocation: BqInvocation): Promise<{
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+}> {
+  const separator = invocation.args.indexOf("--");
+  const command = invocation.args[separator + 1];
+  const args = invocation.args.slice(separator + 2);
+  const cwdIndex = invocation.args.indexOf("--cwd");
+  const cwd = invocation.args[cwdIndex + 1];
+
+  return new Promise((resolveRun, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env: invocation.env,
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString("utf8"); });
+    child.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString("utf8"); });
+    child.once("error", reject);
+    child.once("close", (code, signal) => resolveRun({ code, signal, stdout, stderr }));
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) =>
+    rm(directory, { recursive: true, force: true })
+  ));
+});
+
+describe("scheduler submission", () => {
+  it("submits an exact literal bq invocation and returns its immediate acceptance result", async () => {
+    const cwd = await temporaryDirectory();
+    const invocations: BqInvocation[] = [];
+    const bqResult: BqProcessResult = {
+      code: 0,
+      signal: null,
+      stdout: "bq: accepted Job job-1 (queued)\n",
+      stderr: "notice\n",
+      stdoutTruncated: false,
+      stderrTruncated: false,
+      cancelled: false,
+    };
+    const session = await SchedulerSession.start({
+      onWake: () => undefined,
+      runBq: async (invocation) => {
+        invocations.push(invocation);
+        return bqResult;
+      },
+    });
+
+    try {
+      const result = await session.submit({
+        reentryPrompt: "Recheck the deployment and report whether it is healthy.",
+        timing: { in: "10m", every: "30m", count: 4 },
+        payload: {
+          executable: "/usr/bin/printf",
+          args: ["%s", "literal; $(not a shell)"],
+          cwd,
+        },
+      }, cwd);
+
+      expect(result).toMatchObject({ accepted: true, bq: bqResult });
+      expect(invocations).toHaveLength(1);
+      const invocation = invocations[0];
+      expect(invocation.command).toBe("bq");
+      expect(invocation.cwd).toBe(cwd);
+      expect(invocation).not.toHaveProperty("shell");
+      expect(invocation.args.slice(0, 9)).toEqual([
+        "--cwd", cwd,
+        "--in", "10m",
+        "--every", "30m",
+        "--count", "4",
+        "--",
+      ]);
+      expect(invocation.args[9]).toMatch(/\/extensions\/scheduler\/callback-runner\.mjs$/);
+      const socketPath = valueAfter(invocation, "--socket");
+      const capability = valueAfter(invocation, "--capability");
+      expect(socketPath).toMatch(/\/ompi-scheduler-[^/]+\/wake\.sock$/);
+      expect(capability).toMatch(/^[A-Za-z0-9_-]{43}$/);
+      expect(invocation.args.slice(10, 16)).toEqual([
+        "--socket", socketPath,
+        "--capability", capability,
+        "--submission", result.submissionId,
+      ]);
+      expect(invocation.args[16]).toBe("--prompt-base64");
+      expect(Buffer.from(invocation.args[17], "base64url").toString("utf8")).toBe(
+        "Recheck the deployment and report whether it is healthy.",
+      );
+      expect(invocation.args.slice(18)).toEqual([
+        "--",
+        "/usr/bin/printf",
+        "%s",
+        "literal; $(not a shell)",
+      ]);
+      expect(invocation.env).toHaveProperty("PATH", process.env.PATH);
+      expect(invocation.env).not.toHaveProperty("OPENAI_API_KEY");
+    } finally {
+      await session.close();
+    }
+  });
+
+  it("returns a failed bq acceptance result without reporting it as accepted", async () => {
+    const cwd = await temporaryDirectory();
+    const session = await SchedulerSession.start({
+      onWake: () => undefined,
+      runBq: async () => ({
+        code: 2,
+        signal: null,
+        stdout: "partial acceptance output\n",
+        stderr: "bq: invalid timing\n",
+        stdoutTruncated: false,
+        stderrTruncated: false,
+        cancelled: false,
+      }),
+    });
+
+    try {
+      const result = await session.submit({
+        reentryPrompt: "Correct the rejected scheduler request using the diagnostics.",
+        timing: { in: "invalid" },
+      }, cwd);
+
+      expect(result).toMatchObject({
+        accepted: false,
+        bq: {
+          code: 2,
+          signal: null,
+          stdout: "partial acceptance output\n",
+          stderr: "bq: invalid timing\n",
+        },
+      });
+    } finally {
+      await session.close();
+    }
+  });
+
+  it("delivers a heartbeat wake through the real private Unix socket", async () => {
+    const cwd = await temporaryDirectory();
+    let invocation: BqInvocation | undefined;
+    const wakes: SchedulerWake[] = [];
+    const session = await SchedulerSession.start({
+      onWake: (wake) => wakes.push(wake),
+      runBq: async (candidate) => {
+        invocation = candidate;
+        return {
+          code: 0,
+          signal: null,
+          stdout: "bq: accepted Job heartbeat (queued)\n",
+          stderr: "",
+          stdoutTruncated: false,
+          stderrTruncated: false,
+          cancelled: false,
+        };
+      },
+    });
+
+    try {
+      const submission = await session.submit({
+        reentryPrompt: "Review the current incident state and decide the next safe action.",
+      }, cwd);
+      if (!invocation) throw new Error("bq invocation was not captured");
+
+      const runner = await runQueuedInvocation(invocation);
+
+      expect(runner).toMatchObject({ code: 0, signal: null, stdout: "", stderr: "" });
+      expect(wakes).toHaveLength(1);
+      expect(wakes[0]).toMatchObject({
+        submissionId: submission.submissionId,
+        reentryPrompt: "Review the current incident state and decide the next safe action.",
+        outcome: { kind: "heartbeat" },
+        stdout: { preview: "", truncated: false },
+        stderr: { preview: "", truncated: false },
+      });
+    } finally {
+      await session.close();
+    }
+  });
+
+  it("forwards payload streams while waking with bounded previews after success", async () => {
+    const cwd = await temporaryDirectory();
+    let invocation: BqInvocation | undefined;
+    const wakes: SchedulerWake[] = [];
+    const session = await SchedulerSession.start({
+      onWake: (wake) => wakes.push(wake),
+      runBq: async (candidate) => {
+        invocation = candidate;
+        return {
+          code: 0,
+          signal: null,
+          stdout: "accepted\n",
+          stderr: "",
+          stdoutTruncated: false,
+          stderrTruncated: false,
+          cancelled: false,
+        };
+      },
+    });
+
+    try {
+      await session.submit({
+        reentryPrompt: "Inspect the command result and continue the maintenance check.",
+        payload: {
+          executable: process.execPath,
+          args: [
+            "--input-type=module",
+            "--eval",
+            "process.stdout.write('o'.repeat(6000)); process.stderr.write('e'.repeat(6000));",
+          ],
+        },
+      }, cwd);
+      if (!invocation) throw new Error("bq invocation was not captured");
+
+      const runner = await runQueuedInvocation(invocation);
+
+      expect(runner).toMatchObject({
+        code: 0,
+        signal: null,
+        stdout: "o".repeat(6_000),
+        stderr: "e".repeat(6_000),
+      });
+      expect(wakes).toHaveLength(1);
+      expect(wakes[0]).toMatchObject({
+        outcome: { kind: "exit", code: 0 },
+        stdout: { preview: "o".repeat(4_000), truncated: true },
+        stderr: { preview: "e".repeat(4_000), truncated: true },
+      });
+    } finally {
+      await session.close();
+    }
+  });
+
+  it("keeps multibyte payload previews within the callback byte limit", async () => {
+    const cwd = await temporaryDirectory();
+    let invocation: BqInvocation | undefined;
+    const wakes: SchedulerWake[] = [];
+    const session = await SchedulerSession.start({
+      onWake: (wake) => wakes.push(wake),
+      runBq: async (candidate) => {
+        invocation = candidate;
+        return {
+          code: 0,
+          signal: null,
+          stdout: "accepted\n",
+          stderr: "",
+          stdoutTruncated: false,
+          stderrTruncated: false,
+          cancelled: false,
+        };
+      },
+    });
+
+    try {
+      await session.submit({
+        reentryPrompt: "Use the bounded Unicode preview to continue the deferred check.",
+        payload: {
+          executable: process.execPath,
+          args: ["--input-type=module", "--eval", "process.stdout.write('€'.repeat(2000));"],
+        },
+      }, cwd);
+      if (!invocation) throw new Error("bq invocation was not captured");
+
+      const runner = await runQueuedInvocation(invocation);
+
+      expect(runner.code).toBe(0);
+      expect(wakes).toHaveLength(1);
+      expect(Buffer.byteLength(wakes[0].stdout.preview, "utf8")).toBeLessThanOrEqual(4_000);
+      expect(wakes[0].stdout.truncated).toBe(true);
+    } finally {
+      await session.close();
+    }
+  });
+
+  it("preserves a nonzero payload exit and delivers exactly one mechanical outcome", async () => {
+    const cwd = await temporaryDirectory();
+    let invocation: BqInvocation | undefined;
+    const wakes: SchedulerWake[] = [];
+    const session = await SchedulerSession.start({
+      onWake: (wake) => wakes.push(wake),
+      runBq: async (candidate) => {
+        invocation = candidate;
+        return {
+          code: 0,
+          signal: null,
+          stdout: "accepted\n",
+          stderr: "",
+          stdoutTruncated: false,
+          stderrTruncated: false,
+          cancelled: false,
+        };
+      },
+    });
+
+    try {
+      await session.submit({
+        reentryPrompt: "Use the failed check to diagnose the next action without assuming Queue state.",
+        payload: {
+          executable: process.execPath,
+          args: ["--input-type=module", "--eval", "process.stderr.write('failed check'); process.exitCode = 7;"],
+        },
+      }, cwd);
+      if (!invocation) throw new Error("bq invocation was not captured");
+
+      const runner = await runQueuedInvocation(invocation);
+
+      expect(runner).toMatchObject({ code: 7, signal: null, stderr: "failed check" });
+      expect(wakes).toHaveLength(1);
+      expect(wakes[0]).toMatchObject({
+        outcome: { kind: "exit", code: 7 },
+        stderr: { preview: "failed check", truncated: false },
+      });
+    } finally {
+      await session.close();
+    }
+  });
+
+  it("preserves payload signal termination after delivering its wake", async () => {
+    const cwd = await temporaryDirectory();
+    let invocation: BqInvocation | undefined;
+    const wakes: SchedulerWake[] = [];
+    const session = await SchedulerSession.start({
+      onWake: (wake) => wakes.push(wake),
+      runBq: async (candidate) => {
+        invocation = candidate;
+        return {
+          code: 0,
+          signal: null,
+          stdout: "accepted\n",
+          stderr: "",
+          stdoutTruncated: false,
+          stderrTruncated: false,
+          cancelled: false,
+        };
+      },
+    });
+
+    try {
+      await session.submit({
+        reentryPrompt: "Handle the terminated check and choose whether a safer retry is appropriate.",
+        payload: {
+          executable: process.execPath,
+          args: ["--input-type=module", "--eval", "process.kill(process.pid, 'SIGTERM');"],
+        },
+      }, cwd);
+      if (!invocation) throw new Error("bq invocation was not captured");
+
+      const runner = await runQueuedInvocation(invocation);
+
+      expect(runner).toMatchObject({ code: null, signal: "SIGTERM" });
+      expect(wakes).toHaveLength(1);
+      expect(wakes[0]).toMatchObject({ outcome: { kind: "signal", signal: "SIGTERM" } });
+    } finally {
+      await session.close();
+    }
+  });
+
+  it("reports a command-start failure in the wake and runner diagnostics", async () => {
+    const cwd = await temporaryDirectory();
+    let invocation: BqInvocation | undefined;
+    const wakes: SchedulerWake[] = [];
+    const missingExecutable = join(cwd, "missing-payload");
+    const session = await SchedulerSession.start({
+      onWake: (wake) => wakes.push(wake),
+      runBq: async (candidate) => {
+        invocation = candidate;
+        return {
+          code: 0,
+          signal: null,
+          stdout: "accepted\n",
+          stderr: "",
+          stdoutTruncated: false,
+          stderrTruncated: false,
+          cancelled: false,
+        };
+      },
+    });
+
+    try {
+      await session.submit({
+        reentryPrompt: "Diagnose why the deferred command could not start and propose a corrected executable.",
+        payload: { executable: missingExecutable },
+      }, cwd);
+      if (!invocation) throw new Error("bq invocation was not captured");
+
+      const runner = await runQueuedInvocation(invocation);
+
+      expect(runner.code).toBe(127);
+      expect(runner.stderr).toContain("scheduler callback runner: payload start failed:");
+      expect(wakes).toHaveLength(1);
+      expect(wakes[0].outcome).toMatchObject({
+        kind: "start_error",
+        message: expect.stringContaining("ENOENT"),
+      });
+    } finally {
+      await session.close();
+    }
+  });
+
+  it("reports when a heartbeat can no longer reach its live session endpoint", async () => {
+    const cwd = await temporaryDirectory();
+    let invocation: BqInvocation | undefined;
+    const session = await SchedulerSession.start({
+      onWake: () => undefined,
+      runBq: async (candidate) => {
+        invocation = candidate;
+        return {
+          code: 0,
+          signal: null,
+          stdout: "accepted\n",
+          stderr: "",
+          stdoutTruncated: false,
+          stderrTruncated: false,
+          cancelled: false,
+        };
+      },
+    });
+    await session.submit({
+      reentryPrompt: "This wake cannot be delivered after its owning session closes.",
+    }, cwd);
+    if (!invocation) throw new Error("bq invocation was not captured");
+    await session.close();
+
+    const runner = await runQueuedInvocation(invocation);
+
+    expect(runner.code).toBe(1);
+    expect(runner.stderr).toContain("scheduler callback runner: callback unavailable:");
+  });
+
+  it("rejects unauthorized and malformed callback frames without a wake", async () => {
+    const cwd = await temporaryDirectory();
+    const wakes: SchedulerWake[] = [];
+    const prompt = "Reenter only from the authorized scheduler callback.";
+    let invocation: BqInvocation | undefined;
+    const session = await SchedulerSession.start({
+      onWake: (wake) => wakes.push(wake),
+      runBq: async (candidate) => {
+        invocation = candidate;
+        return {
+          code: 0,
+          signal: null,
+          stdout: "accepted\n",
+          stderr: "",
+          stdoutTruncated: false,
+          stderrTruncated: false,
+          cancelled: false,
+        };
+      },
+    });
+
+    try {
+      const submission = await session.submit({ reentryPrompt: prompt }, cwd);
+      if (!invocation) throw new Error("bq invocation was not captured");
+      const socketPath = valueAfter(invocation, "--socket");
+      const baseFrame = {
+        version: 1,
+        capability: valueAfter(invocation, "--capability"),
+        submissionId: submission.submissionId,
+        wakeId: "4d88e8de-bdd3-49bf-ad4f-ff4841c309c6",
+        reentryPrompt: prompt,
+        outcome: { kind: "heartbeat" },
+        stdout: { preview: "", truncated: false },
+        stderr: { preview: "", truncated: false },
+      };
+
+      const unauthorized = await sendRawCallback(socketPath, {
+        ...baseFrame,
+        capability: "not-the-session-capability",
+      });
+      const malformed = await sendRawCallback(socketPath, {
+        ...baseFrame,
+        unexpected: true,
+      });
+
+      expect(JSON.parse(unauthorized)).toEqual({ version: 1, ok: false });
+      expect(JSON.parse(malformed)).toEqual({ version: 1, ok: false });
+      expect(wakes).toEqual([]);
+    } finally {
+      await session.close();
+    }
+  });
+
+  it("delivers a correlated wake ID only once", async () => {
+    const cwd = await temporaryDirectory();
+    const wakes: SchedulerWake[] = [];
+    const prompt = "Continue this one scheduler occurrence exactly once.";
+    let invocation: BqInvocation | undefined;
+    const session = await SchedulerSession.start({
+      onWake: (wake) => wakes.push(wake),
+      runBq: async (candidate) => {
+        invocation = candidate;
+        return {
+          code: 0,
+          signal: null,
+          stdout: "accepted\n",
+          stderr: "",
+          stdoutTruncated: false,
+          stderrTruncated: false,
+          cancelled: false,
+        };
+      },
+    });
+
+    try {
+      const submission = await session.submit({ reentryPrompt: prompt }, cwd);
+      if (!invocation) throw new Error("bq invocation was not captured");
+      const socketPath = valueAfter(invocation, "--socket");
+      const frame = {
+        version: 1,
+        capability: valueAfter(invocation, "--capability"),
+        submissionId: submission.submissionId,
+        wakeId: "5123f981-9f2b-48a8-a779-664319b2f6f1",
+        reentryPrompt: prompt,
+        outcome: { kind: "heartbeat" },
+        stdout: { preview: "", truncated: false },
+        stderr: { preview: "", truncated: false },
+      };
+
+      expect(JSON.parse(await sendRawCallback(socketPath, frame))).toEqual({ version: 1, ok: true });
+      expect(JSON.parse(await sendRawCallback(socketPath, frame))).toEqual({ version: 1, ok: false });
+      expect(wakes).toHaveLength(1);
+    } finally {
+      await session.close();
+    }
+  });
+
+  it("bounds the queued literal argument vector before invoking bq", async () => {
+    const cwd = await temporaryDirectory();
+    let bqCalls = 0;
+    const session = await SchedulerSession.start({
+      onWake: () => undefined,
+      runBq: async () => {
+        bqCalls++;
+        return {
+          code: 0,
+          signal: null,
+          stdout: "accepted\n",
+          stderr: "",
+          stdoutTruncated: false,
+          stderrTruncated: false,
+          cancelled: false,
+        };
+      },
+    });
+
+    try {
+      await expect(session.submit({
+        reentryPrompt: "Correct the oversized command request before resubmitting it.",
+        payload: { executable: "/usr/bin/true", args: Array(129).fill("argument") },
+      }, cwd)).rejects.toThrow("at most 128 literal arguments");
+      expect(bqCalls).toBe(0);
+    } finally {
+      await session.close();
+    }
+  });
+
+  it("rejects unavailable working directories and callback helpers before invoking bq", async () => {
+    const cwd = await temporaryDirectory();
+    let bqCalls = 0;
+    const bq = async (): Promise<BqProcessResult> => {
+      bqCalls++;
+      return {
+        code: 0,
+        signal: null,
+        stdout: "accepted\n",
+        stderr: "",
+        stdoutTruncated: false,
+        stderrTruncated: false,
+        cancelled: false,
+      };
+    };
+    const missingHelper = join(cwd, "missing-callback-runner.mjs");
+    const missingDirectory = join(cwd, "missing-directory");
+    const normal = await SchedulerSession.start({ onWake: () => undefined, runBq: bq });
+    const noHelper = await SchedulerSession.start({
+      onWake: () => undefined,
+      runBq: bq,
+      callbackRunnerPath: missingHelper,
+    });
+
+    try {
+      await expect(normal.submit({
+        reentryPrompt: "Retry only after correcting the working directory.",
+        payload: { executable: "/usr/bin/true", cwd: missingDirectory },
+      }, cwd)).rejects.toThrow("working directory is unavailable");
+      await expect(noHelper.submit({
+        reentryPrompt: "Retry only after restoring the callback helper.",
+      }, cwd)).rejects.toThrow("callback helper is unavailable");
+      expect(bqCalls).toBe(0);
+    } finally {
+      await normal.close();
+      await noHelper.close();
+    }
+  });
+
+  it("closes the session endpoint idempotently and removes its private runtime directory", async () => {
+    const cwd = await temporaryDirectory();
+    let invocation: BqInvocation | undefined;
+    const session = await SchedulerSession.start({
+      onWake: () => undefined,
+      runBq: async (candidate) => {
+        invocation = candidate;
+        return {
+          code: 0,
+          signal: null,
+          stdout: "accepted\n",
+          stderr: "",
+          stdoutTruncated: false,
+          stderrTruncated: false,
+          cancelled: false,
+        };
+      },
+    });
+    await session.submit({ reentryPrompt: "Capture the endpoint for shutdown cleanup." }, cwd);
+    if (!invocation) throw new Error("bq invocation was not captured");
+    const socketPath = valueAfter(invocation, "--socket");
+    const runtimeDirectory = join(socketPath, "..");
+
+    const socketMetadata = await lstat(socketPath);
+    const directoryMetadata = await lstat(runtimeDirectory);
+    expect(socketMetadata.isSocket()).toBe(true);
+    expect(socketMetadata.mode & 0o777).toBe(0o600);
+    expect(directoryMetadata.mode & 0o777).toBe(0o700);
+    await session.close();
+    await session.close();
+
+    await expect(lstat(socketPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(lstat(runtimeDirectory)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(session.submit({ reentryPrompt: "too late" }, cwd)).rejects.toThrow(
+      "callback endpoint is unavailable",
+    );
+  });
+});

--- a/extensions/scheduler/scheduler.test.ts
+++ b/extensions/scheduler/scheduler.test.ts
@@ -115,7 +115,7 @@ describe("scheduler submission", () => {
         },
       }, cwd);
 
-      expect(result).toMatchObject({ accepted: true, bq: bqResult });
+      expect(result).toMatchObject({ acceptance: "confirmed", bq: bqResult });
       expect(invocations).toHaveLength(1);
       const invocation = invocations[0];
       expect(invocation.command).toBe("bq");
@@ -155,7 +155,7 @@ describe("scheduler submission", () => {
     }
   });
 
-  it("returns a failed bq acceptance result without reporting it as accepted", async () => {
+  it("reports nonzero bq acceptance as unknown because durable work may already exist", async () => {
     const cwd = await temporaryDirectory();
     const session = await SchedulerSession.start({
       onWake: () => undefined,
@@ -177,7 +177,7 @@ describe("scheduler submission", () => {
       }, cwd);
 
       expect(result).toMatchObject({
-        accepted: false,
+        acceptance: "unknown",
         bq: {
           code: 2,
           signal: null,
@@ -416,7 +416,9 @@ describe("scheduler submission", () => {
     }
   });
 
-  it("preserves payload signal termination after delivering its wake", async () => {
+  it.each(["SIGTERM", "SIGPIPE", "SIGUSR1"] as const)(
+    "preserves payload %s termination after delivering its wake",
+    async (payloadSignal) => {
     const cwd = await temporaryDirectory();
     let invocation: BqInvocation | undefined;
     const wakes: SchedulerWake[] = [];
@@ -441,16 +443,20 @@ describe("scheduler submission", () => {
         reentryPrompt: "Handle the terminated check and choose whether a safer retry is appropriate.",
         payload: {
           executable: process.execPath,
-          args: ["--input-type=module", "--eval", "process.kill(process.pid, 'SIGTERM');"],
+          args: [
+            "--input-type=module",
+            "--eval",
+            `const restore=()=>{}; process.on('${payloadSignal}', restore); process.off('${payloadSignal}', restore); process.kill(process.pid, '${payloadSignal}');`,
+          ],
         },
       }, cwd);
       if (!invocation) throw new Error("bq invocation was not captured");
 
       const runner = await runQueuedInvocation(invocation);
 
-      expect(runner).toMatchObject({ code: null, signal: "SIGTERM" });
+      expect(runner).toMatchObject({ code: null, signal: payloadSignal });
       expect(wakes).toHaveLength(1);
-      expect(wakes[0]).toMatchObject({ outcome: { kind: "signal", signal: "SIGTERM" } });
+      expect(wakes[0]).toMatchObject({ outcome: { kind: "signal", signal: payloadSignal } });
     } finally {
       await session.close();
     }
@@ -528,7 +534,7 @@ describe("scheduler submission", () => {
     expect(runner.stderr).toContain("scheduler callback runner: callback unavailable:");
   });
 
-  it("fails a successful payload when its wake can no longer be delivered", async () => {
+  it("preserves a successful payload outcome when its best-effort wake cannot be delivered", async () => {
     const cwd = await temporaryDirectory();
     let invocation: BqInvocation | undefined;
     const session = await SchedulerSession.start({
@@ -555,7 +561,7 @@ describe("scheduler submission", () => {
 
     const runner = await runQueuedInvocation(invocation);
 
-    expect(runner.code).toBe(1);
+    expect(runner.code).toBe(0);
     expect(runner.stderr).toContain("scheduler callback runner: callback unavailable:");
   });
 

--- a/extensions/scheduler/scheduler.test.ts
+++ b/extensions/scheduler/scheduler.test.ts
@@ -26,16 +26,27 @@ function valueAfter(invocation: BqInvocation, option: string): string {
   return value;
 }
 
-async function sendRawCallback(socketPath: string, frame: unknown): Promise<string> {
+async function sendCallbackChunks(socketPath: string, chunks: string[]): Promise<string> {
   return new Promise((resolveSend, reject) => {
     const socket = createConnection(socketPath);
     let response = "";
     socket.setEncoding("utf8");
-    socket.once("connect", () => socket.end(`${JSON.stringify(frame)}\n`, "utf8"));
+    socket.once("connect", async () => {
+      for (const chunk of chunks) {
+        await new Promise<void>((resolveWrite, rejectWrite) => {
+          socket.write(chunk, "utf8", (error) => error ? rejectWrite(error) : resolveWrite());
+        });
+      }
+      socket.end();
+    });
     socket.on("data", (chunk: string) => { response += chunk; });
     socket.once("end", () => resolveSend(response));
     socket.once("error", reject);
   });
+}
+
+async function sendRawCallback(socketPath: string, frame: unknown): Promise<string> {
+  return sendCallbackChunks(socketPath, [`${JSON.stringify(frame)}\n`]);
 }
 
 async function runQueuedInvocation(invocation: BqInvocation): Promise<{
@@ -315,6 +326,53 @@ describe("scheduler submission", () => {
     }
   });
 
+  it("accepts maximum escaped prompt and preview content within the bounded protocol", async () => {
+    const cwd = await temporaryDirectory();
+    let invocation: BqInvocation | undefined;
+    const wakes: SchedulerWake[] = [];
+    const session = await SchedulerSession.start({
+      onWake: (wake) => wakes.push(wake),
+      runBq: async (candidate) => {
+        invocation = candidate;
+        return {
+          code: 0,
+          signal: null,
+          stdout: "accepted\n",
+          stderr: "",
+          stdoutTruncated: false,
+          stderrTruncated: false,
+          cancelled: false,
+        };
+      },
+    });
+    const prompt = `Continue ${"\n".repeat(7_980)}now`;
+
+    try {
+      await session.submit({
+        reentryPrompt: prompt,
+        payload: {
+          executable: process.execPath,
+          args: [
+            "--input-type=module",
+            "--eval",
+            "process.stdout.write('\\n'.repeat(5000)); process.stderr.write('\\n'.repeat(5000));",
+          ],
+        },
+      }, cwd);
+      if (!invocation) throw new Error("bq invocation was not captured");
+
+      const runner = await runQueuedInvocation(invocation);
+
+      expect(runner.code).toBe(0);
+      expect(wakes).toHaveLength(1);
+      expect(wakes[0].reentryPrompt).toBe(prompt);
+      expect(wakes[0].stdout).toEqual({ preview: "\n".repeat(4_000), truncated: true });
+      expect(wakes[0].stderr).toEqual({ preview: "\n".repeat(4_000), truncated: true });
+    } finally {
+      await session.close();
+    }
+  });
+
   it("preserves a nonzero payload exit and delivers exactly one mechanical outcome", async () => {
     const cwd = await temporaryDirectory();
     let invocation: BqInvocation | undefined;
@@ -470,6 +528,37 @@ describe("scheduler submission", () => {
     expect(runner.stderr).toContain("scheduler callback runner: callback unavailable:");
   });
 
+  it("fails a successful payload when its wake can no longer be delivered", async () => {
+    const cwd = await temporaryDirectory();
+    let invocation: BqInvocation | undefined;
+    const session = await SchedulerSession.start({
+      onWake: () => undefined,
+      runBq: async (candidate) => {
+        invocation = candidate;
+        return {
+          code: 0,
+          signal: null,
+          stdout: "accepted\n",
+          stderr: "",
+          stdoutTruncated: false,
+          stderrTruncated: false,
+          cancelled: false,
+        };
+      },
+    });
+    await session.submit({
+      reentryPrompt: "A successful payload must not hide failure to deliver its scheduler wake.",
+      payload: { executable: process.execPath, args: ["--eval", "process.exitCode = 0"] },
+    }, cwd);
+    if (!invocation) throw new Error("bq invocation was not captured");
+    await session.close();
+
+    const runner = await runQueuedInvocation(invocation);
+
+    expect(runner.code).toBe(1);
+    expect(runner.stderr).toContain("scheduler callback runner: callback unavailable:");
+  });
+
   it("rejects unauthorized and malformed callback frames without a wake", async () => {
     const cwd = await temporaryDirectory();
     const wakes: SchedulerWake[] = [];
@@ -514,9 +603,14 @@ describe("scheduler submission", () => {
         ...baseFrame,
         unexpected: true,
       });
+      const extraFrame = await sendCallbackChunks(socketPath, [
+        `${JSON.stringify(baseFrame)}\n`,
+        `${JSON.stringify(baseFrame)}\n`,
+      ]);
 
       expect(JSON.parse(unauthorized)).toEqual({ version: 1, ok: false });
       expect(JSON.parse(malformed)).toEqual({ version: 1, ok: false });
+      expect(JSON.parse(extraFrame)).toEqual({ version: 1, ok: false });
       expect(wakes).toEqual([]);
     } finally {
       await session.close();

--- a/extensions/scheduler/scheduler.ts
+++ b/extensions/scheduler/scheduler.ts
@@ -9,7 +9,7 @@ import { runBqProcess } from "./process.ts";
 
 const CALLBACK_RUNNER = fileURLToPath(new URL("./callback-runner.mjs", import.meta.url));
 const CALLBACK_PROTOCOL_VERSION = 1;
-const MAX_CALLBACK_FRAME_BYTES = 24_000;
+const MAX_CALLBACK_FRAME_BYTES = 128_000;
 const MAX_REENTRY_PROMPT_BYTES = 8_000;
 const MAX_PREVIEW_BYTES = 4_000;
 const MAX_START_ERROR_BYTES = 2_000;
@@ -445,9 +445,11 @@ export class SchedulerSession {
         return;
       }
       buffer = Buffer.concat([buffer, chunk]);
+    });
+    socket.once("end", () => {
+      if (handled) return;
       const newline = buffer.indexOf(0x0a);
-      if (newline < 0) return;
-      if (buffer.subarray(newline + 1).toString("utf8").trim()) {
+      if (newline < 0 || newline !== buffer.length - 1) {
         reject();
         return;
       }
@@ -473,9 +475,6 @@ export class SchedulerSession {
         this.deliveredWakeIds.delete(frame.wakeId);
         socket.end(`${JSON.stringify({ version: CALLBACK_PROTOCOL_VERSION, ok: false })}\n`);
       }
-    });
-    socket.once("end", () => {
-      if (!handled) reject();
     });
     socket.once("error", () => socket.destroy());
   }

--- a/extensions/scheduler/scheduler.ts
+++ b/extensions/scheduler/scheduler.ts
@@ -1,0 +1,496 @@
+import { randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
+import { constants } from "node:fs";
+import { access, chmod, lstat, mkdtemp, rmdir, stat, unlink } from "node:fs/promises";
+import { createServer, type Server, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runBqProcess } from "./process.ts";
+
+const CALLBACK_RUNNER = fileURLToPath(new URL("./callback-runner.mjs", import.meta.url));
+const CALLBACK_PROTOCOL_VERSION = 1;
+const MAX_CALLBACK_FRAME_BYTES = 24_000;
+const MAX_REENTRY_PROMPT_BYTES = 8_000;
+const MAX_PREVIEW_BYTES = 4_000;
+const MAX_START_ERROR_BYTES = 2_000;
+const MAX_PAYLOAD_ARGUMENTS = 128;
+const MAX_ARGUMENT_BYTES = 8_000;
+const MAX_TOTAL_ARGUMENT_BYTES = 64_000;
+const MAX_TIMING_VALUE_BYTES = 1_024;
+const SOCKET_READ_TIMEOUT_MS = 2_000;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const CAPABILITY_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+const BQ_ENVIRONMENT_KEYS = [
+  "HOME",
+  "LANG",
+  "LC_ALL",
+  "LC_CTYPE",
+  "LOGNAME",
+  "PATH",
+  "SHELL",
+  "TMPDIR",
+  "TZ",
+  "USER",
+  "BQ_OMQUEUE",
+] as const;
+
+export interface SchedulerTiming {
+  in?: string;
+  at?: string;
+  cron?: string;
+  tz?: string;
+  every?: string;
+  count?: number;
+}
+
+export interface SchedulerPayload {
+  executable: string;
+  args?: string[];
+  cwd?: string;
+}
+
+export interface SchedulerSubmitInput {
+  reentryPrompt: string;
+  timing?: SchedulerTiming;
+  payload?: SchedulerPayload;
+}
+
+export interface BqInvocation {
+  command: string;
+  args: string[];
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  signal?: AbortSignal;
+}
+
+export interface BqProcessResult {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  stdoutTruncated: boolean;
+  stderrTruncated: boolean;
+  cancelled: boolean;
+}
+
+export interface SchedulerSubmissionResult {
+  accepted: boolean;
+  submissionId: string;
+  bq: BqProcessResult;
+}
+
+export interface SchedulerStreamPreview {
+  preview: string;
+  truncated: boolean;
+}
+
+export type SchedulerPayloadOutcome =
+  | { kind: "heartbeat" }
+  | { kind: "exit"; code: number }
+  | { kind: "signal"; signal: string }
+  | { kind: "start_error"; message: string };
+
+export interface SchedulerWake {
+  submissionId: string;
+  wakeId: string;
+  reentryPrompt: string;
+  outcome: SchedulerPayloadOutcome;
+  stdout: SchedulerStreamPreview;
+  stderr: SchedulerStreamPreview;
+}
+
+interface CallbackFrame extends SchedulerWake {
+  version: number;
+  capability: string;
+}
+
+interface SchedulerSessionOptions {
+  onWake(wake: SchedulerWake): void;
+  runBq?: (invocation: BqInvocation) => Promise<BqProcessResult>;
+  callbackRunnerPath?: string;
+  environment?: NodeJS.ProcessEnv;
+}
+
+function selectedEnvironment(source: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = {};
+  for (const key of BQ_ENVIRONMENT_KEYS) {
+    const value = source[key];
+    if (value !== undefined) environment[key] = value;
+  }
+  return environment;
+}
+
+function hasExactKeys(value: object, expected: string[]): boolean {
+  const actual = Object.keys(value).sort();
+  const sortedExpected = [...expected].sort();
+  return actual.length === sortedExpected.length
+    && actual.every((key, index) => key === sortedExpected[index]);
+}
+
+function byteLengthWithin(value: string, maximum: number): boolean {
+  return Buffer.byteLength(value, "utf8") <= maximum;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isPreview(value: unknown): value is SchedulerStreamPreview {
+  return isRecord(value)
+    && hasExactKeys(value, ["preview", "truncated"])
+    && typeof value.preview === "string"
+    && byteLengthWithin(value.preview, MAX_PREVIEW_BYTES)
+    && typeof value.truncated === "boolean";
+}
+
+function isOutcome(value: unknown): value is SchedulerPayloadOutcome {
+  if (!isRecord(value) || typeof value.kind !== "string") return false;
+  if (value.kind === "heartbeat") return hasExactKeys(value, ["kind"]);
+  if (value.kind === "exit") {
+    return hasExactKeys(value, ["kind", "code"])
+      && typeof value.code === "number"
+      && Number.isInteger(value.code)
+      && value.code >= 0
+      && value.code <= 255;
+  }
+  if (value.kind === "signal") {
+    return hasExactKeys(value, ["kind", "signal"])
+      && typeof value.signal === "string"
+      && /^[A-Z][A-Z0-9]{1,15}$/.test(value.signal);
+  }
+  if (value.kind === "start_error") {
+    return hasExactKeys(value, ["kind", "message"])
+      && typeof value.message === "string"
+      && byteLengthWithin(value.message, MAX_START_ERROR_BYTES);
+  }
+  return false;
+}
+
+function parseCallbackFrame(line: string): CallbackFrame | undefined {
+  let value: unknown;
+  try {
+    value = JSON.parse(line);
+  } catch {
+    return undefined;
+  }
+  if (!isRecord(value) || !hasExactKeys(value, [
+    "version",
+    "capability",
+    "submissionId",
+    "wakeId",
+    "reentryPrompt",
+    "outcome",
+    "stdout",
+    "stderr",
+  ])) return undefined;
+  if (value.version !== CALLBACK_PROTOCOL_VERSION
+    || typeof value.capability !== "string"
+    || !CAPABILITY_PATTERN.test(value.capability)
+    || typeof value.submissionId !== "string"
+    || !UUID_PATTERN.test(value.submissionId)
+    || typeof value.wakeId !== "string"
+    || !UUID_PATTERN.test(value.wakeId)
+    || typeof value.reentryPrompt !== "string"
+    || !byteLengthWithin(value.reentryPrompt, MAX_REENTRY_PROMPT_BYTES)
+    || !isOutcome(value.outcome)
+    || !isPreview(value.stdout)
+    || !isPreview(value.stderr)) return undefined;
+  return value as unknown as CallbackFrame;
+}
+
+function capabilitiesMatch(actual: string, expected: string): boolean {
+  const actualBuffer = Buffer.from(actual, "utf8");
+  const expectedBuffer = Buffer.from(expected, "utf8");
+  return actualBuffer.length === expectedBuffer.length
+    && timingSafeEqual(actualBuffer, expectedBuffer);
+}
+
+function assertBoundedSubmitInput(input: SchedulerSubmitInput): void {
+  if (!input.reentryPrompt.trim()) {
+    throw new Error("scheduler_submit requires a complete reentry prompt.");
+  }
+  if (!byteLengthWithin(input.reentryPrompt, MAX_REENTRY_PROMPT_BYTES)) {
+    throw new Error(`Scheduler reentry prompt exceeds ${MAX_REENTRY_PROMPT_BYTES} UTF-8 bytes.`);
+  }
+
+  if (input.timing) {
+    for (const [name, value] of Object.entries(input.timing)) {
+      if (typeof value === "string" && !byteLengthWithin(value, MAX_TIMING_VALUE_BYTES)) {
+        throw new Error(`Scheduler timing value ${name} exceeds ${MAX_TIMING_VALUE_BYTES} UTF-8 bytes.`);
+      }
+    }
+  }
+
+  if (!input.payload) return;
+  if (!input.payload.executable.trim()) {
+    throw new Error("Scheduler payload executable must not be empty.");
+  }
+  if (!byteLengthWithin(input.payload.executable, MAX_ARGUMENT_BYTES)) {
+    throw new Error(`Scheduler payload executable exceeds ${MAX_ARGUMENT_BYTES} UTF-8 bytes.`);
+  }
+  if (input.payload.cwd && !byteLengthWithin(input.payload.cwd, MAX_ARGUMENT_BYTES)) {
+    throw new Error(`Scheduler working directory exceeds ${MAX_ARGUMENT_BYTES} UTF-8 bytes.`);
+  }
+  const arguments_ = input.payload.args ?? [];
+  if (arguments_.length > MAX_PAYLOAD_ARGUMENTS) {
+    throw new Error(`Scheduler payload accepts at most ${MAX_PAYLOAD_ARGUMENTS} literal arguments.`);
+  }
+  let totalBytes = 0;
+  for (const argument of arguments_) {
+    const bytes = Buffer.byteLength(argument, "utf8");
+    if (bytes > MAX_ARGUMENT_BYTES) {
+      throw new Error(`A scheduler payload argument exceeds ${MAX_ARGUMENT_BYTES} UTF-8 bytes.`);
+    }
+    totalBytes += bytes;
+  }
+  if (totalBytes > MAX_TOTAL_ARGUMENT_BYTES) {
+    throw new Error(`Scheduler payload arguments exceed ${MAX_TOTAL_ARGUMENT_BYTES} total UTF-8 bytes.`);
+  }
+}
+
+function timingArguments(timing: SchedulerTiming | undefined): string[] {
+  if (!timing) return [];
+  const arguments_: string[] = [];
+  if (timing.in !== undefined) arguments_.push("--in", timing.in);
+  if (timing.at !== undefined) arguments_.push("--at", timing.at);
+  if (timing.cron !== undefined) arguments_.push("--cron", timing.cron);
+  if (timing.tz !== undefined) arguments_.push("--tz", timing.tz);
+  if (timing.every !== undefined) arguments_.push("--every", timing.every);
+  if (timing.count !== undefined) arguments_.push("--count", String(timing.count));
+  return arguments_;
+}
+
+async function assertDirectory(path: string): Promise<void> {
+  let metadata;
+  try {
+    metadata = await stat(path);
+    await access(path, constants.X_OK);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Scheduler working directory is unavailable: ${path}. ${message}`);
+  }
+  if (!metadata.isDirectory()) {
+    throw new Error(`Scheduler working directory is not a directory: ${path}.`);
+  }
+}
+
+async function assertExecutable(path: string): Promise<void> {
+  try {
+    const metadata = await stat(path);
+    if (!metadata.isFile()) throw new Error("not a regular file");
+    await access(path, constants.X_OK);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Scheduler callback helper is unavailable: ${path}. ${message}`);
+  }
+}
+
+async function listen(server: Server, socketPath: string): Promise<void> {
+  await new Promise<void>((resolveListen, reject) => {
+    const onError = (error: Error) => {
+      server.off("listening", onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      resolveListen();
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(socketPath);
+  });
+}
+
+export class SchedulerSession {
+  private readonly socketPath: string;
+  private readonly capability: string;
+  private readonly callbackDirectory: string;
+  private readonly server: Server;
+  private readonly sockets = new Set<Socket>();
+  private readonly runBq: (invocation: BqInvocation) => Promise<BqProcessResult>;
+  private readonly callbackRunnerPath: string;
+  private readonly environment: NodeJS.ProcessEnv;
+  private readonly onWake: (wake: SchedulerWake) => void;
+  private readonly submissions = new Map<string, string>();
+  private readonly deliveredWakeIds = new Set<string>();
+  private closed = false;
+
+  private constructor(
+    callbackDirectory: string,
+    socketPath: string,
+    capability: string,
+    server: Server,
+    options: SchedulerSessionOptions,
+  ) {
+    this.callbackDirectory = callbackDirectory;
+    this.socketPath = socketPath;
+    this.capability = capability;
+    this.server = server;
+    this.runBq = options.runBq ?? runBqProcess;
+    this.callbackRunnerPath = options.callbackRunnerPath ?? CALLBACK_RUNNER;
+    this.environment = selectedEnvironment(options.environment ?? process.env);
+    this.onWake = options.onWake;
+  }
+
+  static async start(options: SchedulerSessionOptions): Promise<SchedulerSession> {
+    const callbackDirectory = await mkdtemp(join(tmpdir(), "ompi-scheduler-"));
+    try {
+      await chmod(callbackDirectory, 0o700);
+    } catch (error) {
+      await rmdir(callbackDirectory).catch(() => undefined);
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Scheduler callback endpoint is unavailable: ${message}`);
+    }
+    const socketPath = join(callbackDirectory, "wake.sock");
+    const capability = randomBytes(32).toString("base64url");
+    const server = createServer();
+    const session = new SchedulerSession(
+      callbackDirectory,
+      socketPath,
+      capability,
+      server,
+      options,
+    );
+    server.on("connection", (socket) => session.receive(socket));
+
+    try {
+      await listen(server, socketPath);
+      await chmod(socketPath, 0o600);
+      return session;
+    } catch (error) {
+      server.close();
+      await unlink(socketPath).catch(() => undefined);
+      await rmdir(callbackDirectory).catch(() => undefined);
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Scheduler callback endpoint is unavailable: ${message}`);
+    }
+  }
+
+  async submit(
+    input: SchedulerSubmitInput,
+    sessionCwd: string,
+    signal?: AbortSignal,
+  ): Promise<SchedulerSubmissionResult> {
+    if (this.closed || !this.server.listening) {
+      throw new Error("Scheduler callback endpoint is unavailable for this session.");
+    }
+    assertBoundedSubmitInput(input);
+
+    const cwd = resolve(sessionCwd, input.payload?.cwd ?? ".");
+    await assertDirectory(cwd);
+    await assertExecutable(this.callbackRunnerPath);
+    const socketMetadata = await lstat(this.socketPath).catch(() => undefined);
+    if (!socketMetadata?.isSocket()) {
+      throw new Error(`Scheduler callback endpoint is unavailable: ${this.socketPath}.`);
+    }
+
+    const submissionId = randomUUID();
+    this.submissions.set(submissionId, input.reentryPrompt);
+    const runnerArguments = [
+      this.callbackRunnerPath,
+      "--socket", this.socketPath,
+      "--capability", this.capability,
+      "--submission", submissionId,
+      "--prompt-base64", Buffer.from(input.reentryPrompt, "utf8").toString("base64url"),
+    ];
+    if (input.payload) {
+      runnerArguments.push("--", input.payload.executable, ...(input.payload.args ?? []));
+    }
+    const args = [
+      "--cwd", cwd,
+      ...timingArguments(input.timing),
+      "--",
+      ...runnerArguments,
+    ];
+    let bq: BqProcessResult;
+    try {
+      bq = await this.runBq({
+        command: "bq",
+        args,
+        cwd: isAbsolute(sessionCwd) ? sessionCwd : resolve(sessionCwd),
+        env: { ...this.environment },
+        signal,
+      });
+    } catch (error) {
+      this.submissions.delete(submissionId);
+      throw error;
+    }
+
+    // A nonzero finite-repeat submission may have accepted earlier occurrences
+    // before a later one failed, so retain callback correlation once bq started.
+    return {
+      accepted: bq.code === 0 && bq.signal === null && !bq.cancelled,
+      submissionId,
+      bq,
+    };
+  }
+
+  private receive(socket: Socket): void {
+    this.sockets.add(socket);
+    socket.once("close", () => this.sockets.delete(socket));
+    socket.setTimeout(SOCKET_READ_TIMEOUT_MS, () => socket.destroy());
+    let buffer = Buffer.alloc(0);
+    let handled = false;
+
+    const reject = () => {
+      if (handled) return;
+      handled = true;
+      socket.end(`${JSON.stringify({ version: CALLBACK_PROTOCOL_VERSION, ok: false })}\n`);
+    };
+
+    socket.on("data", (chunk: Buffer) => {
+      if (handled) return;
+      if (buffer.length + chunk.length > MAX_CALLBACK_FRAME_BYTES) {
+        reject();
+        return;
+      }
+      buffer = Buffer.concat([buffer, chunk]);
+      const newline = buffer.indexOf(0x0a);
+      if (newline < 0) return;
+      if (buffer.subarray(newline + 1).toString("utf8").trim()) {
+        reject();
+        return;
+      }
+
+      const frame = parseCallbackFrame(buffer.subarray(0, newline).toString("utf8"));
+      const expectedPrompt = frame ? this.submissions.get(frame.submissionId) : undefined;
+      if (!frame
+        || !capabilitiesMatch(frame.capability, this.capability)
+        || expectedPrompt === undefined
+        || frame.reentryPrompt !== expectedPrompt
+        || this.deliveredWakeIds.has(frame.wakeId)) {
+        reject();
+        return;
+      }
+
+      handled = true;
+      this.deliveredWakeIds.add(frame.wakeId);
+      const { version: _version, capability: _capability, ...wake } = frame;
+      try {
+        this.onWake(wake);
+        socket.end(`${JSON.stringify({ version: CALLBACK_PROTOCOL_VERSION, ok: true })}\n`);
+      } catch {
+        this.deliveredWakeIds.delete(frame.wakeId);
+        socket.end(`${JSON.stringify({ version: CALLBACK_PROTOCOL_VERSION, ok: false })}\n`);
+      }
+    });
+    socket.once("end", () => {
+      if (!handled) reject();
+    });
+    socket.once("error", () => socket.destroy());
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    this.submissions.clear();
+    this.deliveredWakeIds.clear();
+    for (const socket of this.sockets) socket.destroy();
+    this.sockets.clear();
+    if (this.server.listening) {
+      await new Promise<void>((resolveClose) => this.server.close(() => resolveClose()));
+    }
+    await unlink(this.socketPath).catch(() => undefined);
+    await rmdir(this.callbackDirectory).catch(() => undefined);
+  }
+}

--- a/extensions/scheduler/scheduler.ts
+++ b/extensions/scheduler/scheduler.ts
@@ -74,7 +74,7 @@ export interface BqProcessResult {
 }
 
 export interface SchedulerSubmissionResult {
-  accepted: boolean;
+  acceptance: "confirmed" | "unknown";
   submissionId: string;
   bq: BqProcessResult;
 }
@@ -419,7 +419,9 @@ export class SchedulerSession {
     // A nonzero finite-repeat submission may have accepted earlier occurrences
     // before a later one failed, so retain callback correlation once bq started.
     return {
-      accepted: bq.code === 0 && bq.signal === null && !bq.cancelled,
+      acceptance: bq.code === 0 && bq.signal === null && !bq.cancelled
+        ? "confirmed"
+        : "unknown",
       submissionId,
       bq,
     };

--- a/justfile
+++ b/justfile
@@ -17,6 +17,10 @@ research:
 orchestrate:
     pi --no-skills --skill "${HOME}/.pi/agent/skills/handoff" --skill "${HOME}/.pi/agent/skills/tmux-worker" --skill "${HOME}/.pi/agent/skills/wormhole" --no-extensions --extension "${HOME}/.pi/agent/extensions/exit-alias.ts" --no-prompt-templates --no-context-files --append-system-prompt ./AGENTS.md
 
+# Start Pi with the fire-and-forget scheduler wake extension and the exit alias
+scheduler:
+    pi --no-skills --no-extensions --extension "${HOME}/.pi/agent/extensions/exit-alias.ts" --extension ./extensions/scheduler/index.ts --no-prompt-templates --no-context-files --append-system-prompt ./AGENTS.md
+
 # Start Pi with the asynchronous subagent extension and the exit alias
 subagents:
     pi --no-skills --no-extensions --extension "${HOME}/.pi/agent/extensions/exit-alias.ts" --extension ./extensions/subagents/index.ts --no-prompt-templates --no-context-files --append-system-prompt ./AGENTS.md


### PR DESCRIPTION
## Summary

- add an opt-in `scheduler_submit` extension above the existing global `bq` wrapper
- deliver bounded, authenticated live-session wakes through a private Unix socket
- run optional shell-free payloads while preserving streams and mechanical outcomes
- document scheduler vocabulary, security boundaries, and explicit launch profile

## Verification

- `npm test` (49 passed)
- `npm run typecheck`
- `just --list`
- `just --dry-run scheduler`
- `git diff --check`

## Review

Independent read-only review completed against `5834f85167118b1e8b0552581de145ca6e2a0cb8`; all three findings were corrected.

Closes #4