### PR TITLE
fix(subagents): inherit active model and reasoning

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,10 @@ The extension exposes these tools and matching commands:
 | `subagent_list` | `/sublist` | List session-scoped known conversations |
 
 Use plain command arguments for common operations, or JSON with `/sub` and
-`/subcont` for model, thinking-level, working-directory, tool, and name options.
-For example:
+`/subcont` for working-directory, tool, and name options. Every start and
+continuation inherits the orchestrator's active model and thinking level at the
+moment that turn is dispatched; agent and command inputs cannot override either
+choice. For example:
 
 ```text
 /sub Inspect the authentication flow and report risks.

--- a/docs/subagents/CONTEXT.md
+++ b/docs/subagents/CONTEXT.md
@@ -40,6 +40,14 @@ _Avoid_: Model callback, polling, status check
 A compact Pi widget near the editor that shows current subagent activity without adding streaming updates to the orchestrator conversation. A minimal footer count remains visible while any subagent turn is active.
 _Avoid_: Transcript message, progress polling, full output
 
+## Routing inheritance
+
+Every clean start and continuation inherits the orchestrator's active model and
+current Pi thinking level when that turn is dispatched. Agent-facing tools and
+command JSON cannot override those human-controlled choices. A model or thinking
+change in the orchestrator therefore applies to the next dispatched subagent
+turn, including a continuation of an existing conversation.
+
 ## Turn-release contract
 
 After a start confirmation, the orchestrator must never keep its current turn alive merely to await the pong. It must not use sleeps, shell wait loops, or repeated status snapshots. It may continue useful work that does not depend on the subagent's result; otherwise it ends its response immediately. Ending the response returns control to the user and lets the queued pong enter the orchestrator conversation in a later turn.

--- a/extensions/subagents/controller.test.ts
+++ b/extensions/subagents/controller.test.ts
@@ -95,6 +95,7 @@ describe("SubagentController", () => {
 
     children[0].acceptPrompt();
     await expect(starting).resolves.toMatchObject({ id: 1, state: "running" });
+    expect(children[0].spec).toMatchObject({ model: "p/m", thinking: "high" });
     expect(pongs).toEqual([]);
   });
 
@@ -142,14 +143,14 @@ describe("SubagentController", () => {
     expect(pongs[0]).toMatchObject({ outcome: "failed", error: "provider failed" });
   });
 
-  it("continues with the same session and inherited prior configuration", async () => {
+  it("continues the same session with the routing values supplied for the new turn", async () => {
     const { controller, children } = setup();
-    await controller.start({ prompt: "one", cwd: "/repo", model: "p/m", thinking: "high", tools: ["read"] });
+    await controller.start({ prompt: "one", cwd: "/repo", model: "p/old", thinking: "low", tools: ["read"] });
     await settle(children[0]);
 
-    await controller.continue({ id: 1, prompt: "two" });
-    expect(children[1].spec).toMatchObject({ session: "/sessions/1.jsonl", cwd: "/repo", model: "p/m", thinking: "high", tools: ["read"] });
-    await expect(controller.continue({ id: 1, prompt: "three" })).rejects.toThrow("active");
+    await controller.continue({ id: 1, prompt: "two", model: "p/current", thinking: "high" });
+    expect(children[1].spec).toMatchObject({ session: "/sessions/1.jsonl", cwd: "/repo", model: "p/current", thinking: "high", tools: ["read"] });
+    await expect(controller.continue({ id: 1, prompt: "three", model: "p/current", thinking: "high" })).rejects.toThrow("active");
   });
 
   it("allows steering only while active", async () => {

--- a/extensions/subagents/controller.ts
+++ b/extensions/subagents/controller.ts
@@ -32,8 +32,8 @@ export interface StartInput extends LaunchSpec {
 export interface ContinueInput {
   id: number;
   prompt: string;
-  model?: string;
-  thinking?: ThinkingLevel;
+  model: string;
+  thinking: ThinkingLevel;
   tools?: string[];
 }
 
@@ -162,8 +162,8 @@ export class SubagentController {
       thinking: record.thinking,
       tools: record.tools ? [...record.tools] : undefined,
     };
-    record.model = input.model ?? record.model;
-    record.thinking = input.thinking ?? record.thinking;
+    record.model = input.model;
+    record.thinking = input.thinking;
     if (input.tools !== undefined) record.tools = [...input.tools];
     record.state = "handshaking";
     record.active = true;

--- a/extensions/subagents/index.ts
+++ b/extensions/subagents/index.ts
@@ -6,7 +6,6 @@ import {
   type ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
 import { Box, Text } from "@earendil-works/pi-tui";
-import { StringEnum } from "@earendil-works/pi-ai";
 import { Type, type Static } from "typebox";
 import {
   SubagentController,
@@ -18,11 +17,9 @@ import {
 } from "./controller.ts";
 import { buildChildInvocation, RpcSubprocess } from "./rpc-child.ts";
 
-const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
 const NATIVE_TOOLS = new Set(["read", "bash", "edit", "write", "grep", "find", "ls"]);
 const PONG_TEXT_LIMIT = 8_000;
 
-const ThinkingSchema = StringEnum(THINKING_LEVELS);
 const ToolsSchema = Type.Array(Type.String(), {
   minItems: 1,
   description: "Allowlist of native Pi tools: read, bash, edit, write, grep, find, ls",
@@ -31,8 +28,6 @@ const ToolsSchema = Type.Array(Type.String(), {
 const StartSchema = Type.Object({
   prompt: Type.String({ description: "Complete initial prompt for the clean subagent conversation" }),
   name: Type.Optional(Type.String({ description: "Native Pi session display name" })),
-  model: Type.Optional(Type.String({ description: "Model override, preferably provider/model" })),
-  thinking: Type.Optional(ThinkingSchema),
   cwd: Type.Optional(Type.String({ description: "Initial working directory; fixed for this conversation" })),
   tools: Type.Optional(ToolsSchema),
 });
@@ -40,8 +35,6 @@ const StartSchema = Type.Object({
 const ContinueSchema = Type.Object({
   id: Type.Integer({ minimum: 1 }),
   prompt: Type.String({ description: "Prompt for the next turn in the existing conversation" }),
-  model: Type.Optional(Type.String()),
-  thinking: Type.Optional(ThinkingSchema),
   tools: Type.Optional(ToolsSchema),
 });
 
@@ -189,20 +182,20 @@ export default function subagentsExtension(pi: ExtensionAPI) {
     const input: StartInput = {
       prompt: params.prompt,
       name: params.name,
-      model: params.model ?? activeModel(ctx),
-      thinking: (params.thinking ?? pi.getThinkingLevel()) as ThinkingLevel,
+      model: activeModel(ctx),
+      thinking: pi.getThinkingLevel() as ThinkingLevel,
       cwd: resolve(ctx.cwd, params.cwd ?? "."),
       tools: validateTools(params.tools),
     };
     return controller.start(input);
   };
 
-  const continueSubagent = (params: ContinueParams): Promise<SubagentView> => {
+  const continueSubagent = (params: ContinueParams, ctx: ExtensionContext): Promise<SubagentView> => {
     const input: ContinueInput = {
       id: params.id,
       prompt: params.prompt,
-      model: params.model,
-      thinking: params.thinking as ThinkingLevel | undefined,
+      model: activeModel(ctx),
+      thinking: pi.getThinkingLevel() as ThinkingLevel,
       tools: validateTools(params.tools),
     };
     return controller.continue(input);
@@ -237,8 +230,8 @@ export default function subagentsExtension(pi: ExtensionAPI) {
       "After subagent_continue accepts a prompt, never wait, sleep, or poll for its result. Continue only useful work independent of that result; otherwise end the response so user input and the later pong can be delivered.",
     ],
     parameters: ContinueSchema,
-    async execute(_id, params) {
-      const view = await continueSubagent(params);
+    async execute(_id, params, _signal, _onUpdate, ctx) {
+      const view = await continueSubagent(params, ctx);
       return {
         content: [{
           type: "text",
@@ -310,7 +303,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
           const parsed = parseIdMessage(args, "Usage: /subcont <id> <prompt>");
           return { id: parsed.id, prompt: parsed.message };
         })();
-        const view = await continueSubagent(params);
+        const view = await continueSubagent(params, ctx);
         ctx.ui.notify(`Subagent #${view.id} continued.`, "info");
       } catch (error) {
         ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");

--- a/extensions/subagents/inheritance.test.ts
+++ b/extensions/subagents/inheritance.test.ts
@@ -1,0 +1,153 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const rpc = vi.hoisted(() => ({
+  invocations: [] as Array<{ args: string[] }>,
+  children: [] as Array<{
+    closed: boolean;
+    emit(event: { type: string }): void;
+  }>,
+}));
+
+vi.mock("./rpc-child.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./rpc-child.ts")>();
+  return {
+    ...actual,
+    RpcSubprocess: class {
+      closed = false;
+      private listeners: Array<(event: { type: string }) => void> = [];
+      private readonly sessionFile: string;
+
+      constructor(invocation: { args: string[] }) {
+        rpc.invocations.push(invocation);
+        const sessionIndex = invocation.args.indexOf("--session");
+        this.sessionFile = sessionIndex >= 0
+          ? invocation.args[sessionIndex + 1]
+          : `/sessions/${rpc.children.length + 1}.jsonl`;
+        rpc.children.push(this);
+      }
+
+      async request(command: Record<string, unknown>): Promise<unknown> {
+        if (command.type === "get_state") return { sessionFile: this.sessionFile };
+        if (command.type === "get_last_assistant_text") return { text: "done" };
+        return undefined;
+      }
+
+      onEvent(listener: (event: { type: string }) => void): () => void {
+        this.listeners.push(listener);
+        return () => undefined;
+      }
+
+      onExit(): () => void {
+        return () => undefined;
+      }
+
+      emit(event: { type: string }): void {
+        for (const listener of this.listeners) listener(event);
+      }
+
+      async close(): Promise<void> {
+        this.closed = true;
+      }
+    },
+  };
+});
+
+import subagentsExtension from "./index.ts";
+
+function valueAfter(args: string[], flag: string): string | undefined {
+  const index = args.indexOf(flag);
+  return index < 0 ? undefined : args[index + 1];
+}
+
+function setup() {
+  const tools = new Map<string, any>();
+  const commands = new Map<string, any>();
+  let thinking = "low";
+  const pi = {
+    registerTool: (tool: { name: string }) => tools.set(tool.name, tool),
+    registerCommand: (name: string, command: unknown) => commands.set(name, command),
+    registerMessageRenderer: () => undefined,
+    on: () => undefined,
+    getThinkingLevel: () => thinking,
+    sendMessage: () => undefined,
+  } as unknown as ExtensionAPI;
+  const notifications: string[] = [];
+  const ctx = {
+    cwd: "/repo",
+    model: { provider: "provider", id: "first" },
+    ui: { notify: (message: string) => notifications.push(message) },
+  } as unknown as ExtensionContext;
+
+  subagentsExtension(pi);
+  return { tools, commands, ctx, notifications, setThinking: (level: string) => { thinking = level; } };
+}
+
+async function settle(index: number): Promise<void> {
+  rpc.children[index].emit({ type: "agent_settled" });
+  await vi.waitFor(() => expect(rpc.children[index].closed).toBe(true));
+}
+
+describe("subagent routing inheritance", () => {
+  beforeEach(() => {
+    rpc.invocations.length = 0;
+    rpc.children.length = 0;
+  });
+
+  it("removes model and thinking from both agent-facing schemas", () => {
+    const { tools } = setup();
+    for (const name of ["subagent_start", "subagent_continue"]) {
+      const properties = tools.get(name).parameters.properties;
+      expect(properties).not.toHaveProperty("model");
+      expect(properties).not.toHaveProperty("thinking");
+    }
+  });
+
+  it("re-reads active routing for every tool dispatch and ignores extra override fields", async () => {
+    const { tools, ctx, setThinking } = setup();
+    const start = tools.get("subagent_start");
+    const continuation = tools.get("subagent_continue");
+
+    await start.execute("start", {
+      prompt: "one",
+      model: "attacker/start",
+      thinking: "max",
+    }, undefined, undefined, ctx);
+    expect(valueAfter(rpc.invocations[0].args, "--model")).toBe("provider/first");
+    expect(valueAfter(rpc.invocations[0].args, "--thinking")).toBe("low");
+    await settle(0);
+
+    (ctx as any).model = { provider: "provider", id: "second" };
+    setThinking("high");
+    await continuation.execute("continue", {
+      id: 1,
+      prompt: "two",
+      model: "attacker/continue",
+      thinking: "off",
+    }, undefined, undefined, ctx);
+    expect(valueAfter(rpc.invocations[1].args, "--model")).toBe("provider/second");
+    expect(valueAfter(rpc.invocations[1].args, "--thinking")).toBe("high");
+  });
+
+  it("ignores routing overrides in /sub and /subcont JSON", async () => {
+    const { commands, ctx, notifications, setThinking } = setup();
+
+    await commands.get("sub").handler(
+      '{"prompt":"one","model":"attacker/start","thinking":"max"}',
+      ctx,
+    );
+    expect(valueAfter(rpc.invocations[0].args, "--model")).toBe("provider/first");
+    expect(valueAfter(rpc.invocations[0].args, "--thinking")).toBe("low");
+    await settle(0);
+
+    (ctx as any).model = { provider: "provider", id: "third" };
+    setThinking("xhigh");
+    await commands.get("subcont").handler(
+      '{"id":1,"prompt":"two","model":"attacker/continue","thinking":"off"}',
+      ctx,
+    );
+    expect(valueAfter(rpc.invocations[1].args, "--model")).toBe("provider/third");
+    expect(valueAfter(rpc.invocations[1].args, "--thinking")).toBe("xhigh");
+    expect(notifications.every((message) => !message.includes("attacker"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- remove model and thinking overrides from subagent tools and command JSON options
- inherit the orchestrator active model and reasoning at every start and continuation dispatch
- document the human-controlled routing contract and cover it through child invocation tests

## Verification

- `npm test` (52 passed)
- `npm run typecheck`
- `git diff --check main...HEAD`

Prompt-audit bypass explicitly authorized by the maintainer.

Closes #6