### PR TITLE
fix(codex-search): bypass repository trust check

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,17 @@ Enable it explicitly for one Pi process:
 pi --no-extensions --extension ./extensions/codex-search/index.ts
 ```
 
-It invokes `codex_search -` directly without a shell and sends the research
-query through stdin. The process has a fixed two-minute timeout and bounded
-captured output. Model and reasoning defaults remain controlled by the
-`codex_search` executable resolved from `PATH`; the extension passes no model,
-reasoning, `--yolo`, ephemeral-container, or arbitrary Codex flags. Its
-model-produced result is not a verified primary source, so requests should ask
-for URLs or citations where relevant and verify those sources separately. The extension is not enabled by any launch profile or
-package manifest.
+It invokes `codex_search --skip-git-repo-check -` directly without a shell and
+sends the research query through stdin. The narrow trust-check bypass allows
+research from new or untrusted working directories without using `--yolo` or
+changing sandbox or approval behavior. The process has a fixed two-minute
+timeout and bounded captured output. Model and reasoning defaults remain
+controlled by the `codex_search` executable resolved from `PATH`; the extension
+passes no model, reasoning, `--yolo`, ephemeral-container, or arbitrary Codex
+flags. Its model-produced result is not a verified primary source, so requests
+should ask for URLs or citations where relevant and verify those sources
+separately. The extension is not enabled by any launch profile or package
+manifest.
 
 For comparison, start Pi with every user skill or its normal discovery
 behavior:

--- a/extensions/codex-search/process.test.ts
+++ b/extensions/codex-search/process.test.ts
@@ -72,9 +72,12 @@ describe("codex_search process wrapper", () => {
     const signal = new AbortController().signal;
     const request = buildCodexSearchRequest("find primary sources", "/repo", signal);
 
+    expect([request.command, ...request.args]).toEqual([
+      "codex_search",
+      "--skip-git-repo-check",
+      "-",
+    ]);
     expect(request).toMatchObject({
-      command: "codex_search",
-      args: ["-"],
       input: "find primary sources",
       cwd: "/repo",
       signal,

--- a/extensions/codex-search/process.ts
+++ b/extensions/codex-search/process.ts
@@ -95,7 +95,7 @@ export function buildCodexSearchRequest(
 ): ProcessRequest {
   return {
     command: "codex_search",
-    args: ["-"],
+    args: ["--skip-git-repo-check", "-"],
     input: query,
     cwd,
     signal,


### PR DESCRIPTION
## Summary

- pass the narrow fixed `--skip-git-repo-check` option before the stdin marker
- preserve shell-free stdin query delivery and every existing process bound
- document why this does not use `--yolo` or broaden sandbox/approval authority

## Verification

- `npm run test:codex-search` (9 passed)
- `npm test` (52 passed)
- `npm run typecheck`
- `git diff --check`

Independent read-only review: PASS with no findings.

Closes #5