### PR TITLE
fix(scheduler): submit callback with absolute Node runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,14 @@ callbacks cannot reopen the session. Manage or cancel such schedules outside
 this extension through explicitly requested ordinary shell or OMQueue
 administration.
 
-The callback runner path is stored in each accepted Job or Schedule and must
-remain executable at that absolute location. Scheduler submissions inherit the
-user's command authority and are not sandboxed. This extension is not enabled by
-any unrelated launch profile or by package discovery in this repository. When a
+The wrapper captures the active Pi process's absolute Node runtime because Queue
+Jobs do not inherit the submitting shell or NVM environment. That runtime is the
+literal executable submitted to `bq`, with the callback runner's absolute path as
+its first argument. Both paths are stored in each accepted Job or Schedule and
+must remain executable at those locations for long-lived schedules. Scheduler
+submissions inherit the user's command authority and are not sandboxed. This
+extension is not enabled by any unrelated launch profile or by package discovery
+in this repository. When a
 user explicitly asks to invoke or inspect raw `bq`, use ordinary bash rather
 than `scheduler_submit`.
 

--- a/docs/scheduler/CONTEXT.md
+++ b/docs/scheduler/CONTEXT.md
@@ -30,10 +30,12 @@ Payloads are never shell command strings.
 _Avoid_: Shell script text, Queue Job definition
 
 **Callback runner**:
-The scheduler-owned executable submitted as the actual `bq` payload. It runs the
-optional payload, forwards its original streams for OMQueue capture, keeps
-bounded previews, sends one callback when mechanically possible, and preserves
-the payload exit or signal outcome.
+The scheduler-owned script invoked by the active Pi process's captured absolute
+Node runtime. The runtime is the actual executable submitted to `bq`, and the
+runner's absolute path is its first argument. The runner executes the optional
+payload, forwards its original streams for OMQueue capture, keeps bounded
+previews, sends one callback when mechanically possible, and preserves the
+payload exit or signal outcome.
 _Avoid_: Queue worker, completion watcher
 
 **Callback endpoint**:
@@ -54,11 +56,15 @@ _Avoid_: Queue completion event, watcher result, durable notification
 - `bq` owns timing syntax, timing validation, durable Job or Schedule
   acceptance, and OMQueue integration.
 - OMQueue remains opaque to the scheduler extension.
-- A scheduler submission invokes `bq` directly with a literal argument vector
-  and returns its bounded stdout, stderr, and exit status without waiting for
-  Queue completion. A zero exit confirms acceptance; every other result leaves
-  acceptance unknown because durable work may already have been created and
-  must not be retried blindly.
+- A scheduler submission invokes `bq` directly with a literal argument vector.
+  Its queued invocation uses the active Pi process's absolute Node runtime and
+  the callback runner's absolute script path because Queue Jobs do not inherit
+  the submitting shell or NVM environment. Long-lived schedules depend on both
+  captured paths remaining executable.
+- The submission returns bounded `bq` stdout, stderr, and exit status without
+  waiting for Queue completion. A zero exit confirms acceptance; every other
+  result leaves acceptance unknown because durable work may already have been
+  created and must not be retried blindly.
 - The extension never calls `omqueue watch`, polls Job state, reads the Queue
   database, or exposes cancellation, retry, history, output retrieval, or other
   Queue administration.

--- a/extensions/scheduler/scheduler.test.ts
+++ b/extensions/scheduler/scheduler.test.ts
@@ -121,28 +121,27 @@ describe("scheduler submission", () => {
       expect(invocation.command).toBe("bq");
       expect(invocation.cwd).toBe(cwd);
       expect(invocation).not.toHaveProperty("shell");
-      expect(invocation.args.slice(0, 9)).toEqual([
+      const runnerPath = invocation.args[10];
+      const socketPath = valueAfter(invocation, "--socket");
+      const capability = valueAfter(invocation, "--capability");
+      expect(runnerPath).toMatch(/\/extensions\/scheduler\/callback-runner\.mjs$/);
+      expect(socketPath).toMatch(/\/ompi-scheduler-[^/]+\/wake\.sock$/);
+      expect(capability).toMatch(/^[A-Za-z0-9_-]{43}$/);
+      expect(invocation.args).toEqual([
         "--cwd", cwd,
         "--in", "10m",
         "--every", "30m",
         "--count", "4",
         "--",
-      ]);
-      expect(invocation.args[9]).toMatch(/\/extensions\/scheduler\/callback-runner\.mjs$/);
-      const socketPath = valueAfter(invocation, "--socket");
-      const capability = valueAfter(invocation, "--capability");
-      expect(socketPath).toMatch(/\/ompi-scheduler-[^/]+\/wake\.sock$/);
-      expect(capability).toMatch(/^[A-Za-z0-9_-]{43}$/);
-      expect(invocation.args.slice(10, 16)).toEqual([
+        process.execPath,
+        runnerPath,
         "--socket", socketPath,
         "--capability", capability,
         "--submission", result.submissionId,
-      ]);
-      expect(invocation.args[16]).toBe("--prompt-base64");
-      expect(Buffer.from(invocation.args[17], "base64url").toString("utf8")).toBe(
-        "Recheck the deployment and report whether it is healthy.",
-      );
-      expect(invocation.args.slice(18)).toEqual([
+        "--prompt-base64", Buffer.from(
+          "Recheck the deployment and report whether it is healthy.",
+          "utf8",
+        ).toString("base64url"),
         "--",
         "/usr/bin/printf",
         "%s",
@@ -196,6 +195,7 @@ describe("scheduler submission", () => {
     const wakes: SchedulerWake[] = [];
     const session = await SchedulerSession.start({
       onWake: (wake) => wakes.push(wake),
+      environment: { PATH: "/queue-path-without-node" },
       runBq: async (candidate) => {
         invocation = candidate;
         return {
@@ -215,6 +215,12 @@ describe("scheduler submission", () => {
         reentryPrompt: "Review the current incident state and decide the next safe action.",
       }, cwd);
       if (!invocation) throw new Error("bq invocation was not captured");
+      const separator = invocation.args.indexOf("--");
+      expect(invocation.env).toEqual({ PATH: "/queue-path-without-node" });
+      expect(invocation.args[separator + 1]).toBe(process.execPath);
+      expect(invocation.args[separator + 2]).toMatch(
+        /\/extensions\/scheduler\/callback-runner\.mjs$/,
+      );
 
       const runner = await runQueuedInvocation(invocation);
 
@@ -691,6 +697,37 @@ describe("scheduler submission", () => {
         reentryPrompt: "Correct the oversized command request before resubmitting it.",
         payload: { executable: "/usr/bin/true", args: Array(129).fill("argument") },
       }, cwd)).rejects.toThrow("at most 128 literal arguments");
+      expect(bqCalls).toBe(0);
+    } finally {
+      await session.close();
+    }
+  });
+
+  it("rejects an unavailable Node runtime before invoking bq", async () => {
+    const cwd = await temporaryDirectory();
+    let bqCalls = 0;
+    const missingRuntime = join(cwd, "missing-node");
+    const session = await SchedulerSession.start({
+      onWake: () => undefined,
+      nodeRuntimePath: missingRuntime,
+      runBq: async () => {
+        bqCalls++;
+        return {
+          code: 0,
+          signal: null,
+          stdout: "accepted\n",
+          stderr: "",
+          stdoutTruncated: false,
+          stderrTruncated: false,
+          cancelled: false,
+        };
+      },
+    });
+
+    try {
+      await expect(session.submit({
+        reentryPrompt: "Retry only after restoring the captured Node runtime.",
+      }, cwd)).rejects.toThrow(`Scheduler Node runtime is unavailable: ${missingRuntime}.`);
       expect(bqCalls).toBe(0);
     } finally {
       await session.close();

--- a/extensions/scheduler/scheduler.ts
+++ b/extensions/scheduler/scheduler.ts
@@ -107,6 +107,7 @@ interface CallbackFrame extends SchedulerWake {
 interface SchedulerSessionOptions {
   onWake(wake: SchedulerWake): void;
   runBq?: (invocation: BqInvocation) => Promise<BqProcessResult>;
+  nodeRuntimePath?: string;
   callbackRunnerPath?: string;
   environment?: NodeJS.ProcessEnv;
 }
@@ -274,14 +275,14 @@ async function assertDirectory(path: string): Promise<void> {
   }
 }
 
-async function assertExecutable(path: string): Promise<void> {
+async function assertExecutable(path: string, name: string): Promise<void> {
   try {
     const metadata = await stat(path);
     if (!metadata.isFile()) throw new Error("not a regular file");
     await access(path, constants.X_OK);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`Scheduler callback helper is unavailable: ${path}. ${message}`);
+    throw new Error(`Scheduler ${name} is unavailable: ${path}. ${message}`);
   }
 }
 
@@ -308,6 +309,7 @@ export class SchedulerSession {
   private readonly server: Server;
   private readonly sockets = new Set<Socket>();
   private readonly runBq: (invocation: BqInvocation) => Promise<BqProcessResult>;
+  private readonly nodeRuntimePath: string;
   private readonly callbackRunnerPath: string;
   private readonly environment: NodeJS.ProcessEnv;
   private readonly onWake: (wake: SchedulerWake) => void;
@@ -327,6 +329,7 @@ export class SchedulerSession {
     this.capability = capability;
     this.server = server;
     this.runBq = options.runBq ?? runBqProcess;
+    this.nodeRuntimePath = options.nodeRuntimePath ?? process.execPath;
     this.callbackRunnerPath = options.callbackRunnerPath ?? CALLBACK_RUNNER;
     this.environment = selectedEnvironment(options.environment ?? process.env);
     this.onWake = options.onWake;
@@ -378,7 +381,8 @@ export class SchedulerSession {
 
     const cwd = resolve(sessionCwd, input.payload?.cwd ?? ".");
     await assertDirectory(cwd);
-    await assertExecutable(this.callbackRunnerPath);
+    await assertExecutable(this.nodeRuntimePath, "Node runtime");
+    await assertExecutable(this.callbackRunnerPath, "callback helper");
     const socketMetadata = await lstat(this.socketPath).catch(() => undefined);
     if (!socketMetadata?.isSocket()) {
       throw new Error(`Scheduler callback endpoint is unavailable: ${this.socketPath}.`);
@@ -400,6 +404,7 @@ export class SchedulerSession {
       "--cwd", cwd,
       ...timingArguments(input.timing),
       "--",
+      this.nodeRuntimePath,
       ...runnerArguments,
     ];
     let bq: BqProcessResult;


### PR DESCRIPTION
## Summary

- submit the captured absolute Node runtime as the queued executable
- validate the runtime and callback runner before invoking `bq`
- cover Queue execution with a `PATH` that cannot resolve `node`
- document runtime capture and long-lived path requirements

## Verification

- `npm test` (53 passed)
- `npm run typecheck`
- `git diff --check`
- independent review: PASS, no findings

Closes #10