### PR TITLE
fix(extensions): clarify concurrent async calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,12 @@ background operation starts, and later delivers one collapsible rendered-text
 result. At most four Browser Fetch operations run concurrently. Output remains
 bounded, Chromium is closed on completion or cancellation, and login, CAPTCHA,
 anti-bot, and unreadable-page responses are reported rather than bypassed.
-An ephemeral loopback proxy resolves every navigation, redirect, HTTP
-subresource, and WebSocket destination, rejects any non-public result, and
-connects to the exact validated IP so Chromium cannot re-resolve it. The proxy
+When multiple rendered-page or other background research calls are independently
+useful, the orchestrator starts them in the same turn so Pi can run them
+concurrently; it does not await one result before starting another. An ephemeral
+loopback proxy resolves every navigation, redirect, HTTP subresource, and
+WebSocket destination, rejects any non-public result, and connects to the exact
+validated IP so Chromium cannot re-resolve it. The proxy
 preserves the original hostname and TLS verification. Service workers are
 disabled so they cannot bypass this network boundary.
 
@@ -74,7 +77,9 @@ and later delivers exactly one collapsible completion or failure result. After
 start confirmation, the orchestrator must not wait or poll; it may continue
 independent work or end its response so the result can enter a later turn.
 
-The background wrapper is limited to four concurrent Codex searches. Closing or
+The background wrapper is limited to four concurrent Codex searches. Independently
+useful Codex or other background research calls can be started in the same turn;
+the orchestrator does not await one result before starting another. Closing or
 reloading the owning Pi session aborts active searches and suppresses stale
 results; this path is intentionally not durable and does not use `bq` or
 OMQueue. The narrow trust-check bypass allows research from new or untrusted
@@ -117,8 +122,11 @@ absolute-time work, finite repetition, and cron schedules. The extension invokes
 the existing global `bq` executable directly without a shell and returns as soon
 as `bq` exits. A zero exit confirms acceptance. Any other result leaves acceptance
 unknown because finite submission may already have created durable work; do not
-blindly retry an unknown result. The extension never waits for payload completion,
-watches OMQueue, polls Job state, or exposes Queue administration.
+blindly retry an unknown result. Independently requested submissions can be
+issued in the same turn so Pi handles their bounded acceptance requests
+concurrently; the orchestrator never waits for one wake before submitting
+another. The extension never waits for payload completion, watches OMQueue,
+polls Job state, or exposes Queue administration.
 
 Every submission requires a complete, self-contained `reentryPrompt`. An
 optional payload contains an executable, literal arguments, and a working
@@ -194,9 +202,11 @@ queues exactly one completion, failure, or interruption pong in the orchestrator
 conversation.
 
 After acceptance, the orchestrator must not sleep, run a wait loop, or repeatedly
-call `subagent_list` for completion. It may continue useful work independent of
-the subagent result; otherwise it must end its response so user input and the
-later pong can enter the conversation.
+call `subagent_list` for completion. When multiple independent delegations are
+useful, it starts them in the same turn so Pi can run them concurrently rather
+than awaiting an earlier pong. It may then continue useful work independent of
+the subagent results; otherwise it must end its response so user input and the
+later pongs can enter the conversation.
 
 For daily use, link this audited extension into Pi's global extension directory:
 

--- a/docs/background-tools/CONTEXT.md
+++ b/docs/background-tools/CONTEXT.md
@@ -39,4 +39,4 @@ The canonical wrapper source is `extensions/background-tool.ts`. Eligible extens
 
 ## Turn-release contract
 
-After start confirmation, the orchestrator must not wait, sleep, or poll for the background result. It may continue useful work independent of that result; otherwise it ends its response so the later result can enter the conversation as a follow-up turn.
+After start confirmation, the orchestrator must not wait, sleep, or poll for the background result. When multiple background operations are independently useful, it starts their calls without awaiting earlier results so Pi can run sibling tool calls concurrently. It may then continue useful work independent of those results; otherwise it ends its response so the later results can enter the conversation as follow-up turns.

--- a/docs/scheduler/CONTEXT.md
+++ b/docs/scheduler/CONTEXT.md
@@ -69,6 +69,9 @@ _Avoid_: Queue completion event, watcher result, durable notification
   waiting for Queue completion. A zero exit confirms acceptance; every other
   result leaves acceptance unknown because durable work may already have been
   created and must not be retried blindly.
+- Independently requested scheduler submissions may be issued as sibling tool
+  calls so Pi can run their bounded acceptance requests concurrently. The
+  orchestrator never waits for one scheduler wake before submitting another.
 - The extension never calls `omqueue watch`, polls Job state, reads the Queue
   database, or exposes cancellation, retry, history, output retrieval, or other
   Queue administration.

--- a/docs/subagents/CONTEXT.md
+++ b/docs/subagents/CONTEXT.md
@@ -50,4 +50,4 @@ turn, including a continuation of an existing conversation.
 
 ## Turn-release contract
 
-After a start confirmation, the orchestrator must never keep its current turn alive merely to await the pong. It must not use sleeps, shell wait loops, or repeated status snapshots. It may continue useful work that does not depend on the subagent's result; otherwise it ends its response immediately. Ending the response returns control to the user and lets the queued pong enter the orchestrator conversation in a later turn.
+After a start confirmation, the orchestrator must never keep its current turn alive merely to await the pong. It must not use sleeps, shell wait loops, or repeated status snapshots. When multiple independent delegations are useful, it starts their subagent calls without awaiting earlier pongs so Pi can run sibling tool calls concurrently. It may then continue useful work that does not depend on the subagents' results; otherwise it ends its response immediately. Ending the response returns control to the user and lets the queued pongs enter the orchestrator conversation in later turns.

--- a/extensions/background-tool.test.ts
+++ b/extensions/background-tool.test.ts
@@ -86,7 +86,10 @@ describe("background tool wrapper", () => {
       { cwd: "/repo" } as ExtensionContext,
     );
 
-    expect(accepted.content[0]).toMatchObject({ type: "text", text: expect.stringContaining("Background task #1") });
+    expect(accepted.content[0]).toMatchObject({
+      type: "text",
+      text: expect.stringMatching(/Do not wait, sleep, or poll.*start it without waiting/s),
+    });
     expect(accepted.details).toMatchObject({ id: 1, toolName: "slow_search", active: true });
     expect(messages).toEqual([]);
     expect(wrapped.parameters).toBe(original.parameters);

--- a/extensions/background-tool.ts
+++ b/extensions/background-tool.ts
@@ -165,7 +165,7 @@ export function createBackgroundToolManager(
           return {
             content: [{
               type: "text",
-              text: `Background task #${id} (${tool.name}) started. Do not wait or poll for completion; its result will arrive later.`,
+              text: `Background task #${id} (${tool.name}) started. Do not wait, sleep, or poll for completion; its result will arrive later. If another independent background call is useful, start it without waiting for this result.`,
             }],
             details: view,
           };

--- a/extensions/browser-fetch/index.test.ts
+++ b/extensions/browser-fetch/index.test.ts
@@ -91,7 +91,9 @@ describe("browser_fetch background delivery", () => {
     expect(accepted.content[0].text).toContain("Background task #1");
     expect(messages).toEqual([]);
     expect(tool.description).toContain("asynchronously");
-    expect(tool.promptGuidelines.join(" ")).toContain("never wait");
+    const guidance = tool.promptGuidelines.join(" ");
+    expect(guidance).toContain("never wait");
+    expect(guidance).toMatch(/independently useful.*same turn.*concurrently.*do not wait/s);
 
     const { browser, close } = fakeBrowser();
     launch.resolve(browser);

--- a/extensions/browser-fetch/index.ts
+++ b/extensions/browser-fetch/index.ts
@@ -212,6 +212,7 @@ export default function (pi: ExtensionAPI) {
 		promptSnippet: "Start an asynchronous rendered-page fetch with headless Chromium",
 		promptGuidelines: [
 			"Use browser_fetch when curl fails, returns blocked or nearly empty HTML, or the requested page requires JavaScript rendering.",
+			"When multiple browser_fetch calls or other background research calls are independently useful, start them in the same turn so Pi can run them concurrently; do not wait for one result before starting another.",
 			"After browser_fetch starts background work, never wait, sleep, or poll for its result. Continue only useful work independent of that result; otherwise end the response so the later background result can be delivered.",
 			"If browser_fetch reports a login, CAPTCHA, anti-bot block, or unreadable page, mark the source unverified instead of guessing.",
 		],

--- a/extensions/codex-search/index.test.ts
+++ b/extensions/codex-search/index.test.ts
@@ -59,7 +59,9 @@ describe("codex_search background delivery", () => {
     expect(accepted.content[0].text).toContain("Background task #1");
     expect(messages).toEqual([]);
     expect(tool.description).toContain("asynchronously");
-    expect(tool.promptGuidelines.join(" ")).toContain("never wait");
+    const guidance = tool.promptGuidelines.join(" ");
+    expect(guidance).toContain("never wait");
+    expect(guidance).toMatch(/independently useful.*same turn.*concurrently.*do not wait/s);
 
     search.resolve({
       stdout: "primary research",

--- a/extensions/codex-search/index.ts
+++ b/extensions/codex-search/index.ts
@@ -26,6 +26,7 @@ export default function codexSearchExtension(pi: ExtensionAPI) {
     promptSnippet: "Start asynchronous Codex web research as a fallback or independent second research path",
     promptGuidelines: [
       "Use codex_search when ordinary browser fetching is blocked or insufficient, or for an independent second research path; request URLs or citations when relevant and verify primary sources separately.",
+      "When multiple codex_search calls or other background research calls are independently useful, start them in the same turn so Pi can run them concurrently; do not wait for one result before starting another.",
       "After codex_search starts background research, never wait, sleep, or poll for its result. Continue only useful work independent of that result; otherwise end the response so the later background result can be delivered.",
     ],
     parameters: QuerySchema,

--- a/extensions/scheduler/index.test.ts
+++ b/extensions/scheduler/index.test.ts
@@ -110,6 +110,7 @@ describe("scheduler extension", () => {
       expect(discovery).toContain("never infer payload success from scheduler acceptance");
       expect(discovery).toContain("state the next action or stopping point");
       expect(discovery).toContain("never wait, sleep, poll");
+      expect(discovery).toMatch(/independent scheduler submissions.*same turn.*concurrently.*do not wait/s);
       expect(discovery).toContain("ordinary bash");
       await handlers.get("session_start")?.({}, ctx);
       const result = await tools[0].execute("call-1", {

--- a/extensions/scheduler/index.ts
+++ b/extensions/scheduler/index.ts
@@ -162,6 +162,7 @@ export function registerSchedulerExtension(
       "Use strict timing values: 10m/2h/1d rather than prose or seconds; finite repeats require in or at plus both every and count; omit timing for an immediate wake.",
       "Before submitting a payload, inspect its executable and directly invoked helpers for required environment variables, PATH entries, working directories, runtimes, stdin or TTY assumptions, and detached child processes; do not assume wholesale inheritance from the interactive shell or expose secret values while checking.",
       "Write payload reentry prompts outcome-conditionally: inspect the wake's mechanical outcome and bounded previews, never infer payload success from scheduler acceptance or call the result an official OMQueue Job state, prohibit unauthorized reruns and Queue inspection, and state the next action or stopping point.",
+      "When multiple independent scheduler submissions are requested, issue their scheduler_submit calls in the same turn so Pi can run them concurrently; do not wait for one wake before submitting another.",
       "After scheduler_submit reports bq acceptance, never wait, sleep, poll, inspect OMQueue, or watch Queue completion; continue only independent work or end the response so a later scheduler wake can be delivered.",
       "When the user explicitly asks to invoke or inspect raw bq behavior, use ordinary bash instead of scheduler_submit.",
     ],

--- a/extensions/subagents/index.ts
+++ b/extensions/subagents/index.ts
@@ -208,6 +208,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
     description: "Start a clean persistent Pi conversation asynchronously. Returns after RPC prompt acceptance; completion arrives later as one pong. Never wait or poll for that pong.",
     promptSnippet: "Start an independent asynchronous Pi conversation with a complete prompt",
     promptGuidelines: [
+      "When multiple independent delegations are useful, issue their subagent_start calls in the same turn so Pi can run them concurrently; do not wait for one pong before starting another.",
       "After subagent_start accepts a prompt, never wait, sleep, or poll for its result. Continue only useful work independent of that result; otherwise end the response so user input and the later pong can be delivered.",
     ],
     parameters: StartSchema,
@@ -216,7 +217,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
       return {
         content: [{
           type: "text",
-          text: `Subagent #${view.id} accepted the prompt and is running. Session: ${view.sessionRef}\nDo not wait, sleep, or poll for completion. Continue independent work or end this response; the pong will arrive later.`,
+          text: `Subagent #${view.id} accepted the prompt and is running. Session: ${view.sessionRef}\nDo not wait, sleep, or poll for completion. Start any other useful independent delegation without waiting, then continue independent work or end this response; the pong will arrive later.`,
         }],
         details: view,
       };

--- a/extensions/subagents/presentation.test.ts
+++ b/extensions/subagents/presentation.test.ts
@@ -33,6 +33,7 @@ describe("subagent tool guidance", () => {
     const guidance = tools.flatMap((tool) => tool.promptGuidelines ?? []).join(" ");
     expect(guidance).toContain("never wait, sleep, or poll");
     expect(guidance).toContain("end the response");
+    expect(guidance).toMatch(/independent delegations.*same turn.*concurrently.*do not wait/s);
     expect(guidance).toContain("subagent_list");
   });
 });


### PR DESCRIPTION
## Summary

- tell agents to launch independently useful asynchronous calls in the same turn
- preserve existing tool-selection and no-wait/no-poll boundaries
- cover the guidance through registered metadata and immediate-result tests
- align canonical context docs and README

## Verification

- `npm test`
- `npm run typecheck`
- clean-context prompt audit: PASS

Closes #12
