### PR TITLE
feat(subagents): allow explicit routing overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,15 +240,17 @@ The extension exposes these tools and matching commands:
 | `subagent_list` | `/sublist` | List session-scoped known conversations |
 
 Use plain command arguments for common operations, or JSON with `/sub` and
-`/subcont` for working-directory, tool, and name options. Every start and
-continuation inherits the orchestrator's active model and thinking level at the
-moment that turn is dispatched; agent and command inputs cannot override either
-choice. The live subagent widget and `/sublist` output show both inherited
+`/subcont` for routing, working-directory, tool, and name options. Each omitted
+routing value inherits the orchestrator's active value when that turn is
+dispatched. Optional `model` (`provider/model`) and `reasoning` overrides apply
+to one dispatch only and must be supplied only when the user explicitly requests
+that routing. The live subagent widget and `/sublist` output show the effective
 routing values. For example:
 
 ```text
 /sub Inspect the authentication flow and report risks.
 /sub {"prompt":"Run the focused tests","name":"tests","tools":["read","bash"]}
+/sub {"prompt":"Inspect memory handling","model":"openai-codex/gpt-5.6-luna","reasoning":"high"}
 /subcont 1 Check the newly changed files.
 /substeer 1 Focus only on the parser.
 /substop 1

--- a/docs/subagents/CONTEXT.md
+++ b/docs/subagents/CONTEXT.md
@@ -40,13 +40,15 @@ _Avoid_: Model callback, polling, status check
 A compact Pi widget near the editor that shows current subagent activity without adding streaming updates to the orchestrator conversation. A minimal footer count remains visible while any subagent turn is active.
 _Avoid_: Transcript message, progress polling, full output
 
-## Routing inheritance
+## Routing selection
 
-Every clean start and continuation inherits the orchestrator's active model and
-current Pi thinking level when that turn is dispatched. Agent-facing tools and
-command JSON cannot override those human-controlled choices. A model or thinking
-change in the orchestrator therefore applies to the next dispatched subagent
-turn, including a continuation of an existing conversation.
+Every clean start and continuation independently inherits each omitted routing
+value from the orchestrator's active model and current Pi thinking level when
+that turn is dispatched. Agent-facing tools and command JSON may provide a
+non-empty Pi `provider/model` selector, a supported `reasoning` level, or both
+for that dispatch only. The orchestrator agent must omit these overrides unless
+the user explicitly requests that routing. An override never becomes a default
+for later continuations.
 
 ## Turn-release contract
 

--- a/extensions/subagents/index.ts
+++ b/extensions/subagents/index.ts
@@ -5,6 +5,7 @@ import {
   type ExtensionAPI,
   type ExtensionContext,
 } from "@earendil-works/pi-coding-agent";
+import { StringEnum } from "@earendil-works/pi-ai";
 import { Box, Text } from "@earendil-works/pi-tui";
 import { Type, type Static } from "typebox";
 import {
@@ -17,9 +18,14 @@ import {
 } from "./controller.ts";
 import { buildChildInvocation, RpcSubprocess } from "./rpc-child.ts";
 
+const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
+const THINKING_LEVEL_SET = new Set<string>(THINKING_LEVELS);
 const NATIVE_TOOLS = new Set(["read", "bash", "edit", "write", "grep", "find", "ls"]);
 const PONG_TEXT_LIMIT = 8_000;
 
+const ReasoningSchema = StringEnum(THINKING_LEVELS, {
+  description: "Reasoning override for this dispatch; omit to inherit the orchestrator's current level",
+});
 const ToolsSchema = Type.Array(Type.String(), {
   minItems: 1,
   description: "Allowlist of native Pi tools: read, bash, edit, write, grep, find, ls",
@@ -28,6 +34,11 @@ const ToolsSchema = Type.Array(Type.String(), {
 const StartSchema = Type.Object({
   prompt: Type.String({ description: "Complete initial prompt for the clean subagent conversation" }),
   name: Type.Optional(Type.String({ description: "Native Pi session display name" })),
+  model: Type.Optional(Type.String({
+    minLength: 1,
+    description: "Pi provider/model override for this dispatch; omit to inherit the orchestrator's active model",
+  })),
+  reasoning: Type.Optional(ReasoningSchema),
   cwd: Type.Optional(Type.String({ description: "Initial working directory; fixed for this conversation" })),
   tools: Type.Optional(ToolsSchema),
 });
@@ -35,6 +46,11 @@ const StartSchema = Type.Object({
 const ContinueSchema = Type.Object({
   id: Type.Integer({ minimum: 1 }),
   prompt: Type.String({ description: "Prompt for the next turn in the existing conversation" }),
+  model: Type.Optional(Type.String({
+    minLength: 1,
+    description: "Pi provider/model override for this dispatch; omit to inherit the orchestrator's active model",
+  })),
+  reasoning: Type.Optional(ReasoningSchema),
   tools: Type.Optional(ToolsSchema),
 });
 
@@ -59,6 +75,22 @@ function validateTools(tools?: string[]): string[] | undefined {
 function activeModel(ctx: ExtensionContext): string {
   if (!ctx.model) throw new Error("The orchestrator has no active model to inherit.");
   return `${ctx.model.provider}/${ctx.model.id}`;
+}
+
+function selectedModel(value: unknown, ctx: ExtensionContext): string {
+  if (value === undefined) return activeModel(ctx);
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error("Model override must be a non-empty Pi provider/model selector.");
+  }
+  return value;
+}
+
+function selectedThinking(value: unknown, inherited: ThinkingLevel): ThinkingLevel {
+  if (value === undefined) return inherited;
+  if (typeof value !== "string" || !THINKING_LEVEL_SET.has(value)) {
+    throw new Error(`Reasoning override must be one of: ${THINKING_LEVELS.join(", ")}.`);
+  }
+  return value as ThinkingLevel;
 }
 
 function oneLine(value: string, limit: number): string {
@@ -183,8 +215,8 @@ export default function subagentsExtension(pi: ExtensionAPI) {
     const input: StartInput = {
       prompt: params.prompt,
       name: params.name,
-      model: activeModel(ctx),
-      thinking: pi.getThinkingLevel() as ThinkingLevel,
+      model: selectedModel(params.model, ctx),
+      thinking: selectedThinking(params.reasoning, pi.getThinkingLevel() as ThinkingLevel),
       cwd: resolve(ctx.cwd, params.cwd ?? "."),
       tools: validateTools(params.tools),
     };
@@ -195,8 +227,8 @@ export default function subagentsExtension(pi: ExtensionAPI) {
     const input: ContinueInput = {
       id: params.id,
       prompt: params.prompt,
-      model: activeModel(ctx),
-      thinking: pi.getThinkingLevel() as ThinkingLevel,
+      model: selectedModel(params.model, ctx),
+      thinking: selectedThinking(params.reasoning, pi.getThinkingLevel() as ThinkingLevel),
       tools: validateTools(params.tools),
     };
     return controller.continue(input);
@@ -205,9 +237,10 @@ export default function subagentsExtension(pi: ExtensionAPI) {
   pi.registerTool({
     name: "subagent_start",
     label: "Start Subagent",
-    description: "Start a clean persistent Pi conversation asynchronously. Returns after RPC prompt acceptance; completion arrives later as one pong. Never wait or poll for that pong.",
+    description: "Start a clean persistent Pi conversation asynchronously. Optional model or reasoning overrides apply to this dispatch and are only for an explicit user request. Returns after RPC prompt acceptance; completion arrives later as one pong. Never wait or poll for that pong.",
     promptSnippet: "Start an independent asynchronous Pi conversation with a complete prompt",
     promptGuidelines: [
+      "Set each subagent_start model or reasoning override only when the user explicitly requests that value for this dispatch; omit every unrequested override so it inherits the orchestrator's active value.",
       "When multiple independent delegations are useful, issue their subagent_start calls in the same turn so Pi can run them concurrently; do not wait for one pong before starting another.",
       "After subagent_start accepts a prompt, never wait, sleep, or poll for its result. Continue only useful work independent of that result; otherwise end the response so user input and the later pong can be delivered.",
     ],
@@ -227,8 +260,9 @@ export default function subagentsExtension(pi: ExtensionAPI) {
   pi.registerTool({
     name: "subagent_continue",
     label: "Continue Subagent",
-    description: "Start another asynchronous turn in a settled known subagent conversation. Returns after prompt acceptance; never wait or poll for completion.",
+    description: "Start another asynchronous turn in a settled known subagent conversation. Optional model or reasoning overrides apply to this dispatch and are only for an explicit user request. Returns after prompt acceptance; never wait or poll for completion.",
     promptGuidelines: [
+      "Set each subagent_continue model or reasoning override only when the user explicitly requests that value for this dispatch; omit every unrequested override so it inherits the orchestrator's active value.",
       "After subagent_continue accepts a prompt, never wait, sleep, or poll for its result. Continue only useful work independent of that result; otherwise end the response so user input and the later pong can be delivered.",
     ],
     parameters: ContinueSchema,

--- a/extensions/subagents/inheritance.test.ts
+++ b/extensions/subagents/inheritance.test.ts
@@ -19,7 +19,7 @@ vi.mock("./rpc-child.ts", async (importOriginal) => {
       private readonly sessionFile: string;
 
       constructor(invocation: { args: string[] }) {
-        rpc.invocations.push(invocation);
+        rpc.invocations.push({ args: invocation.args });
         const sessionIndex = invocation.args.indexOf("--session");
         this.sessionFile = sessionIndex >= 0
           ? invocation.args[sessionIndex + 1]
@@ -94,25 +94,61 @@ describe("subagent routing inheritance", () => {
     rpc.children.length = 0;
   });
 
-  it("removes model and thinking from both agent-facing schemas", () => {
+  it("exposes opt-in routing schemas and explicit-request guidance", () => {
     const { tools } = setup();
+
     for (const name of ["subagent_start", "subagent_continue"]) {
-      const properties = tools.get(name).parameters.properties;
-      expect(properties).not.toHaveProperty("model");
-      expect(properties).not.toHaveProperty("thinking");
+      const tool = tools.get(name);
+      expect(tool.parameters.properties).not.toHaveProperty("provider");
+      expect(tool.parameters.properties).not.toHaveProperty("thinking");
+      expect(tool.parameters.properties.model.minLength).toBe(1);
+      expect(tool.parameters.properties.reasoning.enum).toEqual([
+        "off", "minimal", "low", "medium", "high", "xhigh", "max",
+      ]);
+      expect(tool.description).toContain("explicit user request");
+      expect(tool.promptGuidelines.join(" ")).toContain("only when the user explicitly requests");
+      expect(tool.promptGuidelines.join(" ")).toContain("omit every unrequested override");
     }
   });
 
-  it("re-reads active routing for every tool dispatch and ignores extra override fields", async () => {
+  it("uses explicit routing for a registered-tool start", async () => {
+    const { tools, ctx } = setup();
+    const start = tools.get("subagent_start");
+
+    await start.execute("start", {
+      prompt: "one",
+      model: "requested/luna",
+      reasoning: "high",
+    }, undefined, undefined, ctx);
+
+    expect(valueAfter(rpc.invocations[0].args, "--model")).toBe("requested/luna");
+    expect(valueAfter(rpc.invocations[0].args, "--thinking")).toBe("high");
+  });
+
+  it("uses explicit routing for a registered-tool continuation", async () => {
+    const { tools, ctx } = setup();
+    const start = tools.get("subagent_start");
+    const continuation = tools.get("subagent_continue");
+
+    await start.execute("start", { prompt: "one" }, undefined, undefined, ctx);
+    await settle(0);
+    await continuation.execute("continue", {
+      id: 1,
+      prompt: "two",
+      model: "requested/terra",
+      reasoning: "max",
+    }, undefined, undefined, ctx);
+
+    expect(valueAfter(rpc.invocations[1].args, "--model")).toBe("requested/terra");
+    expect(valueAfter(rpc.invocations[1].args, "--thinking")).toBe("max");
+  });
+
+  it("inherits each then-active routing value when overrides are omitted", async () => {
     const { tools, ctx, setThinking } = setup();
     const start = tools.get("subagent_start");
     const continuation = tools.get("subagent_continue");
 
-    await start.execute("start", {
-      prompt: "one",
-      model: "attacker/start",
-      thinking: "max",
-    }, undefined, undefined, ctx);
+    await start.execute("start", { prompt: "one" }, undefined, undefined, ctx);
     expect(valueAfter(rpc.invocations[0].args, "--model")).toBe("provider/first");
     expect(valueAfter(rpc.invocations[0].args, "--thinking")).toBe("low");
     await settle(0);
@@ -122,32 +158,54 @@ describe("subagent routing inheritance", () => {
     await continuation.execute("continue", {
       id: 1,
       prompt: "two",
-      model: "attacker/continue",
-      thinking: "off",
     }, undefined, undefined, ctx);
     expect(valueAfter(rpc.invocations[1].args, "--model")).toBe("provider/second");
     expect(valueAfter(rpc.invocations[1].args, "--thinking")).toBe("high");
   });
 
-  it("ignores routing overrides in /sub and /subcont JSON", async () => {
-    const { commands, ctx, notifications, setThinking } = setup();
+  it("applies JSON slash-command overrides independently per dispatch", async () => {
+    const { commands, ctx, setThinking } = setup();
 
     await commands.get("sub").handler(
-      '{"prompt":"one","model":"attacker/start","thinking":"max"}',
+      '{"prompt":"one","model":"requested/luna"}',
       ctx,
     );
+    expect(valueAfter(rpc.invocations[0].args, "--model")).toBe("requested/luna");
+    expect(valueAfter(rpc.invocations[0].args, "--thinking")).toBe("low");
+    await settle(0);
+
+    (ctx as any).model = { provider: "provider", id: "second" };
+    setThinking("high");
+    await commands.get("subcont").handler(
+      '{"id":1,"prompt":"two","reasoning":"off"}',
+      ctx,
+    );
+    expect(valueAfter(rpc.invocations[1].args, "--model")).toBe("provider/second");
+    expect(valueAfter(rpc.invocations[1].args, "--thinking")).toBe("off");
+  });
+
+  it("rejects invalid JSON slash-command routing before launch", async () => {
+    const { commands, ctx, notifications } = setup();
+
+    await commands.get("sub").handler('{"prompt":"one","model":""}', ctx);
+    await commands.get("sub").handler('{"prompt":"two","reasoning":"extreme"}', ctx);
+
+    expect(rpc.invocations).toEqual([]);
+    expect(notifications).toHaveLength(2);
+  });
+
+  it("inherits routing for JSON slash-command options when overrides are omitted", async () => {
+    const { commands, ctx, setThinking } = setup();
+
+    await commands.get("sub").handler('{"prompt":"one"}', ctx);
     expect(valueAfter(rpc.invocations[0].args, "--model")).toBe("provider/first");
     expect(valueAfter(rpc.invocations[0].args, "--thinking")).toBe("low");
     await settle(0);
 
     (ctx as any).model = { provider: "provider", id: "third" };
     setThinking("xhigh");
-    await commands.get("subcont").handler(
-      '{"id":1,"prompt":"two","model":"attacker/continue","thinking":"off"}',
-      ctx,
-    );
+    await commands.get("subcont").handler('{"id":1,"prompt":"two"}', ctx);
     expect(valueAfter(rpc.invocations[1].args, "--model")).toBe("provider/third");
     expect(valueAfter(rpc.invocations[1].args, "--thinking")).toBe("xhigh");
-    expect(notifications.every((message) => !message.includes("attacker"))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- add optional per-dispatch `model` and `reasoning` overrides to subagent starts and continuations
- inherit every omitted routing value and restrict overrides through explicit-user-request guidance
- validate JSON command routing, document behavior, and cover tool/command seams
- record pre-implementation and final metadata prompt audits on #14

## Verification

- `npm test` (77 tests)
- `npm run typecheck`
- focused `npm test -- extensions/subagents`

Closes #14
