### PR TITLE
feat(processes): manage session-scoped processes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,9 +38,11 @@ AI context for this repository. Read this before making changes.
 - `extensions/background-tool.ts` — reusable session-scoped wrapper for explicitly selected read-only text tools
 - `extensions/browser-fetch/` — bounded asynchronous Chromium page fetcher
 - `extensions/codex-search/` — bounded, shell-free asynchronous Codex research fallback
+- `extensions/managed-process/` — opt-in session-scoped manager for long-running local processes
 - `extensions/scheduler/` — opt-in fire-and-forget `bq` scheduler wake adapter
 - `extensions/subagents/` — asynchronous native Pi RPC conversation lifecycle
 - `docs/background-tools/CONTEXT.md` — canonical background-tool terminology and lifecycle boundary
+- `docs/managed-processes/CONTEXT.md` — canonical managed-process lifecycle and security boundaries
 - `docs/scheduler/CONTEXT.md` — canonical scheduler terminology and Queue boundary
 - `docs/subagents/CONTEXT.md` — canonical subagent terminology and boundaries
 - `docs/orchestration-exploration.md` — durable orchestration findings

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -4,4 +4,5 @@
 
 - [Session Background Tools](./docs/background-tools/CONTEXT.md) — defines the wrapper for session-scoped asynchronous execution of explicitly selected read-only tools
 - [Pi Scheduler](./docs/scheduler/CONTEXT.md) — defines the language and Queue boundary for fire-and-forget scheduler wakes delivered to a live Pi session
+- [Managed Processes](./docs/managed-processes/CONTEXT.md) — defines the lifecycle and security boundaries for session-scoped long-running local processes
 - [Pi Subagents](./docs/subagents/CONTEXT.md) — defines the language for the internal extension that starts and observes independent Pi agent conversations

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ just bare         # Only the /exit alias extension
 just core         # AGENTS.md and the /exit alias extension
 just research     # Core plus research skill and browser extension
 just orchestrate  # Core plus handoff, tmux-worker, and wormhole skills
-just scheduler    # Core plus the fire-and-forget scheduler wake extension
-just subagents    # Core plus the asynchronous subagent extension
+just scheduler          # Core plus the fire-and-forget scheduler wake extension
+just managed-processes  # Core plus session-scoped long-running processes
+just subagents          # Core plus the asynchronous subagent extension
 ```
 
 These profiles disable automatic discovery of agent-facing resources. Explicit
@@ -124,6 +125,47 @@ behavior:
 just p
 just pi
 ```
+
+## Managed processes
+
+`just managed-processes` explicitly enables the extension in
+`extensions/managed-process/`. It is a separate lifecycle from the finite
+read-only background-tool wrapper. Four tools start a long-running local process,
+list retained process state, retrieve recent output, and stop a process:
+
+| Tool | Purpose |
+| --- | --- |
+| `managed_process_start` | Start an executable with literal arguments and an optional cwd |
+| `managed_process_list` | Take one snapshot of retained lifecycle state |
+| `managed_process_output` | Retrieve bounded recent stdout and stderr tails |
+| `managed_process_stop` | Terminate a known process and its owned Unix process group |
+
+Start returns after the operating system accepts the spawn; it does not wait for
+completion or prove that a server is ready. Commands run directly with no shell,
+stdin is ignored, and no interactive TTY is allocated. The child inherits Pi's
+current environment, including any credentials or SSH-agent authority, and is
+not sandboxed. The extension does not load `.env` files or accept custom
+environment values. Arguments are retained in the Pi session and may be visible
+in the host process table, so do not put secrets in argv.
+
+The manager cannot force an application to bind loopback. Inspect the
+application and pass its verified host/listen option when network exposure
+matters. On Unix, each child owns a detached process group. Stop, leader exit,
+startup cancellation, and Pi session shutdown send SIGTERM, then SIGKILL after a
+bounded grace period and verifies that the group is gone. Permission failures,
+a surviving group, or a missing leader outcome are reported as cleanup failures.
+Descendants that deliberately create another session or process group can escape
+this mechanism. Starts are rejected on Windows because direct-child signaling
+cannot satisfy the ownership contract.
+
+State is session-local and in memory. At most eight processes are active, at
+most sixty-four records are retained, and argument vectors are limited to 128
+items, 8,000 UTF-8 bytes per item, and 64 KiB total. Each record keeps the
+latest 64 KiB from each output stream. One output request returns at most 20 KiB
+per stream and reports omitted earlier bytes. The extension does not inject automatic
+completion turns; list and output calls are concrete snapshots, not polling or
+wait operations. See [Managed Processes](docs/managed-processes/CONTEXT.md) for
+the canonical lifecycle and security contract.
 
 ## Scheduler wakes
 

--- a/docs/managed-processes/CONTEXT.md
+++ b/docs/managed-processes/CONTEXT.md
@@ -1,0 +1,50 @@
+# Managed Processes
+
+Language and boundaries for the opt-in Pi extension that owns long-running local processes for one live session.
+
+## Language
+
+**Managed-process extension**:
+The Pi-facing adapter that starts, observes, and terminates explicitly requested long-running local processes for the owning session.
+_Avoid_: Background-tool wrapper, scheduler, daemon supervisor, sandbox
+
+**Managed process**:
+One executable with a literal argument vector and working directory accepted by the extension. It has a session-local numeric ID, captured output tails, and observable lifecycle state.
+_Avoid_: Background operation, Queue Job, shell command, durable service
+
+**Start confirmation**:
+The immediate tool result emitted after the operating system accepts the spawn. It confirms neither application readiness nor eventual success.
+_Avoid_: Health check, completion, successful server bind
+
+**Process snapshot**:
+One bounded list of retained managed-process records and their current observable state.
+_Avoid_: Watch, polling loop, process table
+
+**Output snapshot**:
+Bounded recent stdout and stderr tails for one retained managed process. Earlier bytes may have been discarded.
+_Avoid_: Complete log, streaming subscription, readiness probe
+
+**Stop request**:
+Explicit process-group termination with SIGTERM and bounded SIGKILL escalation on Unix. Repeating it for a retained terminal process is safe.
+_Avoid_: Graceful application shutdown guarantee, arbitrary signal API
+
+## Boundary contract
+
+- The extension is separate from `extensions/background-tool.ts`. That wrapper owns finite read-only completion tasks; managed processes have explicit observation and termination lifecycles.
+- A managed process is session-scoped and in memory. Records, output, and IDs do not survive reload, session replacement, or Pi exit.
+- Start invokes the executable directly with a literal argument vector and `shell: false`. It does not perform shell expansion, interpolation, redirection, pipelines, or profile loading.
+- The child inherits the active Pi process environment. That environment may include credentials, SSH-agent access, and other authority. The extension does not load `.env` files, accept environment overrides, or enumerate inherited values in diagnostics. Arguments are retained in the Pi session and may also be visible in the host process table, so secrets should not be passed through argv.
+- Stdin is ignored and no interactive TTY is allocated. Programs that require prompts, terminal control, or interactive authentication are not supported managed-process candidates.
+- The extension does not sandbox filesystem, subprocess, or network access. It cannot infer or force loopback binding; callers must inspect and pass the application's verified network-binding options. Start confirmation is not a readiness or health signal.
+- On Unix, each child is a detached process-group leader. Explicit stop, natural leader exit, startup cancellation, and session shutdown signal the owned group with SIGTERM, then SIGKILL after a 750 ms grace period, followed by a bounded group-existence check. Signal permission failures, a surviving group, or a missing leader outcome become `cleanup_failed` rather than a false success. A descendant that deliberately creates a new session or process group can escape this OS mechanism. Starts are rejected on Windows because direct-child signaling cannot satisfy the ownership contract.
+- Natural leader exit triggers group cleanup so ordinary descendants cannot keep a watcher or server alive after the managed leader ends.
+- The extension retains at most eight active processes and sixty-four total records. Inputs allow at most 128 arguments, 8,000 UTF-8 bytes per argument, and 64 KiB across the full argument vector. Each process retains the latest 64 KiB from stdout and 64 KiB from stderr; each output snapshot returns at most 20 KiB per stream. Terminal records are evicted oldest-first without evicting active records.
+- Output is untrusted and can contain control text or sensitive application data. It is returned as bounded text and must be reviewed before publication.
+- The extension emits no automatic completion turn. List and output tools provide concrete snapshots but must not be used in sleep or repeated polling loops.
+- Session shutdown awaits bounded termination attempts for active records, clears retained state, and removes its footer status.
+
+## Implementation ownership
+
+- `extensions/managed-process/controller.ts` owns process state, bounded buffers, process-group termination, limits, and shutdown.
+- `extensions/managed-process/index.ts` owns Pi tool schemas, presentation, guidance, cwd resolution, and session lifecycle wiring.
+- `just managed-processes` is the explicit isolated launch profile.

--- a/docs/managed-processes/CONTEXT.md
+++ b/docs/managed-processes/CONTEXT.md
@@ -40,7 +40,9 @@ _Avoid_: Graceful application shutdown guarantee, arbitrary signal API
 - Natural leader exit triggers group cleanup so ordinary descendants cannot keep a watcher or server alive after the managed leader ends.
 - The extension retains at most eight active processes and sixty-four total records. Inputs allow at most 128 arguments, 8,000 UTF-8 bytes per argument, and 64 KiB across the full argument vector. Each process retains the latest 64 KiB from stdout and 64 KiB from stderr; each output snapshot returns at most 20 KiB per stream. Terminal records are evicted oldest-first without evicting active records.
 - Output is untrusted and can contain control text or sensitive application data. It is returned as bounded text and must be reviewed before publication.
-- The extension emits no automatic completion turn. List and output tools provide concrete snapshots but must not be used in sleep or repeated polling loops.
+- The agent may start a managed process without separate confirmation whenever the user's existing task authorization and safety constraints already cover a genuinely required long-running local process. Expected lifecycle, not elapsed seconds, distinguishes it from finite bash work.
+- The extension emits no automatic completion turn. After start, one concrete bounded output/list snapshot or readiness probe is allowed when needed; later snapshots require a real diagnostic or decision need and must not become sleep or repeated polling loops.
+- The agent explicitly stops a managed process once it is no longer needed. Session-shutdown cleanup is a fallback, not a reason to leave unnecessary processes active.
 - Session shutdown awaits bounded termination attempts for active records, clears retained state, and removes its footer status.
 
 ## Implementation ownership

--- a/extensions/managed-process/controller.test.ts
+++ b/extensions/managed-process/controller.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it, vi } from "vitest";
+import { ManagedProcessController } from "./controller.ts";
+
+describe("ManagedProcessController", () => {
+  it("accepts a shell-free process before completion and preserves literal argv and cwd", async () => {
+    const controller = new ManagedProcessController();
+    const literal = "value with spaces; $(printf not-a-shell)";
+
+    try {
+      const view = await controller.start({
+        executable: process.execPath,
+        args: [
+          "--input-type=module",
+          "--eval",
+          "process.stdout.write(JSON.stringify({ argv: process.argv.slice(1), cwd: process.cwd() }) + '\\n'); setInterval(() => {}, 1000);",
+          literal,
+        ],
+        cwd: process.cwd(),
+      });
+
+      expect(view).toMatchObject({ id: 1, state: "running", active: true, pid: expect.any(Number), pgid: expect.any(Number) });
+      expect(controller.list()).toMatchObject([{ id: 1, executable: process.execPath, cwd: process.cwd() }]);
+
+      await expect.poll(() => controller.output(1).stdout.text).toContain(literal);
+      expect(controller.output(1).stdout.text).toContain(`"cwd":"${process.cwd()}"`);
+    } finally {
+      await controller.shutdown();
+    }
+  });
+
+  it("bounds retained stream memory and each output snapshot", async () => {
+    const controller = new ManagedProcessController({ maxStreamBytes: 32, maxOutputBytes: 8 });
+
+    try {
+      const view = await controller.start({
+        executable: process.execPath,
+        args: ["--input-type=module", "--eval", "process.stdout.write('a'.repeat(80) + 'TAIL'); setInterval(() => {}, 1000);"],
+        cwd: process.cwd(),
+      });
+
+      await expect.poll(() => controller.output(view.id).stdout.observedBytes).toBe(84);
+      expect(controller.output(view.id).stdout).toEqual({
+        text: "aaaaTAIL",
+        retainedBytes: 8,
+        observedBytes: 84,
+        truncated: true,
+      });
+      await expect(() => controller.output(view.id, 9)).toThrow("8");
+    } finally {
+      await controller.shutdown();
+    }
+  });
+
+  it("keeps decoded binary output within the requested UTF-8 byte limit", async () => {
+    const controller = new ManagedProcessController({ maxStreamBytes: 32, maxOutputBytes: 8 });
+
+    try {
+      const view = await controller.start({
+        executable: process.execPath,
+        args: ["--input-type=module", "--eval", "process.stdout.write(Buffer.alloc(32, 255)); setInterval(() => {}, 1000);"],
+        cwd: process.cwd(),
+      });
+      await expect.poll(() => controller.output(view.id).stdout.observedBytes).toBe(32);
+      const output = controller.output(view.id).stdout;
+      expect(Buffer.byteLength(output.text, "utf8")).toBeLessThanOrEqual(8);
+      expect(output.retainedBytes).toBe(Buffer.byteLength(output.text, "utf8"));
+      expect(output.truncated).toBe(true);
+    } finally {
+      await controller.shutdown();
+    }
+  });
+
+  it("stops an owned process group with escalation and is idempotent after termination", async () => {
+    const controller = new ManagedProcessController({ stopGraceMs: 30 });
+    let descendantPid = 0;
+
+    try {
+      const view = await controller.start({
+        executable: process.execPath,
+        args: [
+          "--input-type=module",
+          "--eval",
+          "import { spawn } from 'node:child_process'; const child = spawn(process.execPath, ['--eval', 'process.on(\\\"SIGTERM\\\", () => {}); setInterval(() => {}, 1000)'], { stdio: 'ignore' }); process.stdout.write(String(child.pid) + '\\n'); process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);",
+        ],
+        cwd: process.cwd(),
+      });
+      await expect.poll(() => controller.output(view.id).stdout.text.trim()).toMatch(/^\d+$/);
+      descendantPid = Number(controller.output(view.id).stdout.text.trim());
+
+      const stopped = await controller.stop(view.id);
+      expect(stopped).toMatchObject({ id: view.id, active: false, state: "signaled", exitSignal: "SIGKILL", stopReason: "explicit" });
+      await expect.poll(() => {
+        try {
+          process.kill(descendantPid, 0);
+          return false;
+        } catch {
+          return true;
+        }
+      }).toBe(true);
+      await expect(controller.stop(view.id)).resolves.toEqual(stopped);
+    } finally {
+      await controller.shutdown();
+      if (descendantPid) {
+        try { process.kill(descendantPid, "SIGKILL"); } catch { /* already gone */ }
+      }
+    }
+  });
+
+  it("bounds retained terminal history without evicting active processes", async () => {
+    const controller = new ManagedProcessController({ maxRecords: 2 });
+
+    try {
+      for (let index = 0; index < 3; index += 1) {
+        const view = await controller.start({
+          executable: process.execPath,
+          args: ["--input-type=module", "--eval", `process.exitCode = ${index};`],
+          cwd: process.cwd(),
+        });
+        await expect.poll(() => controller.list().find((item) => item.id === view.id)?.active).toBe(false);
+      }
+
+      expect(controller.list().map((view) => [view.id, view.exitCode])).toEqual([[2, 1], [3, 2]]);
+    } finally {
+      await controller.shutdown();
+    }
+  });
+
+  it("rejects cancellation before spawn acceptance and leaves no active process", async () => {
+    const controller = new ManagedProcessController();
+    const abort = new AbortController();
+
+    try {
+      const starting = controller.start({
+        executable: process.execPath,
+        args: ["--input-type=module", "--eval", "setInterval(() => {}, 1000);"],
+        cwd: process.cwd(),
+        signal: abort.signal,
+      });
+      abort.abort();
+
+      await expect(starting).rejects.toThrow("cancelled before spawn acceptance");
+      await expect.poll(() => controller.list()[0]?.active).toBe(false);
+    } finally {
+      await controller.shutdown();
+    }
+  });
+
+  it("rejects an in-flight start when session shutdown wins before spawn acceptance", async () => {
+    const controller = new ManagedProcessController();
+    const starting = controller.start({
+      executable: process.execPath,
+      args: ["--input-type=module", "--eval", "setInterval(() => {}, 1000);"],
+      cwd: process.cwd(),
+    });
+    const shutdown = controller.shutdown();
+
+    await expect(starting).rejects.toThrow("session shutdown began before spawn acceptance");
+    await shutdown;
+    expect(controller.list()).toEqual([]);
+  });
+
+  it("cleans up remaining process-group members after the leader exits naturally", async () => {
+    const controller = new ManagedProcessController({ stopGraceMs: 30 });
+    let descendantPid = 0;
+
+    try {
+      const view = await controller.start({
+        executable: process.execPath,
+        args: [
+          "--input-type=module",
+          "--eval",
+          "import { spawn } from 'node:child_process'; const child = spawn(process.execPath, ['--eval', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' }); child.unref(); process.stdout.write(String(child.pid) + '\\n');",
+        ],
+        cwd: process.cwd(),
+      });
+      await expect.poll(() => controller.output(view.id).stdout.text.trim()).toMatch(/^\d+$/);
+      descendantPid = Number(controller.output(view.id).stdout.text.trim());
+      await expect.poll(() => controller.list()[0]?.state).toBe("exited");
+      expect(controller.list()[0]).toMatchObject({ active: false, exitCode: 0, stopReason: "leader_exit_cleanup" });
+      await expect.poll(() => {
+        try {
+          process.kill(descendantPid, 0);
+          return false;
+        } catch {
+          return true;
+        }
+      }).toBe(true);
+    } finally {
+      await controller.shutdown();
+      if (descendantPid) {
+        try { process.kill(descendantPid, "SIGKILL"); } catch { /* already gone */ }
+      }
+    }
+  });
+
+  it("rejects launches above the active concurrency limit without queuing work", async () => {
+    const controller = new ManagedProcessController({ maxActive: 1 });
+
+    try {
+      const first = controller.start({
+        executable: process.execPath,
+        args: ["--input-type=module", "--eval", "setInterval(() => {}, 1000);"],
+        cwd: process.cwd(),
+      });
+      await expect(controller.start({
+        executable: process.execPath,
+        args: ["--input-type=module", "--eval", "setInterval(() => {}, 1000);"],
+        cwd: process.cwd(),
+      })).rejects.toThrow("At most 1");
+      await expect(first).resolves.toMatchObject({ state: "running" });
+      expect(controller.list()).toHaveLength(1);
+    } finally {
+      await controller.shutdown();
+    }
+  });
+
+  it("reports startup errors and clears active process state on shutdown", async () => {
+    const controller = new ManagedProcessController({ stopGraceMs: 30 });
+
+    await expect(controller.start({ executable: " ", cwd: process.cwd() })).rejects.toThrow("non-empty");
+    await expect(controller.start({
+      executable: process.execPath,
+      cwd: `${process.cwd()}/missing-managed-process-cwd-${process.pid}`,
+    })).rejects.toThrow("Failed to start");
+    await expect.poll(() => controller.list()[0]?.state).toBe("start_failed");
+    await expect(controller.start({
+      executable: `${process.cwd()}/missing-managed-process-executable-${process.pid}`,
+      cwd: process.cwd(),
+    })).rejects.toThrow("Failed to start");
+
+    const active = await controller.start({
+      executable: process.execPath,
+      args: ["--input-type=module", "--eval", "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);"],
+      cwd: process.cwd(),
+    });
+    await controller.shutdown();
+    expect(controller.list()).toEqual([]);
+    if (active.pid) {
+      await expect.poll(() => {
+        try {
+          process.kill(active.pid!, 0);
+          return false;
+        } catch {
+          return true;
+        }
+      }).toBe(true);
+    }
+  });
+
+  it("does not hang when an escaped descendant keeps the captured pipes open", async () => {
+    const controller = new ManagedProcessController({ stopGraceMs: 20 });
+    let escapedPid = 0;
+
+    try {
+      const view = await controller.start({
+        executable: process.execPath,
+        args: [
+          "--input-type=module",
+          "--eval",
+          "import { spawn } from 'node:child_process'; const child = spawn(process.execPath, ['--eval', 'setInterval(() => {}, 1000)'], { detached: true, stdio: ['ignore', 'inherit', 'inherit'] }); child.unref(); process.stdout.write(String(child.pid) + '\\n');",
+        ],
+        cwd: process.cwd(),
+      });
+      await expect.poll(() => controller.output(view.id).stdout.text.trim()).toMatch(/^\d+$/);
+      escapedPid = Number(controller.output(view.id).stdout.text.trim());
+
+      await expect.poll(() => controller.list()[0]?.active, { timeout: 500 }).toBe(false);
+      expect(controller.list()[0]).toMatchObject({ state: "exited", exitCode: 0 });
+    } finally {
+      await controller.shutdown();
+      if (escapedPid) {
+        try { process.kill(-escapedPid, "SIGKILL"); } catch {
+          try { process.kill(escapedPid, "SIGKILL"); } catch { /* already gone */ }
+        }
+      }
+    }
+  });
+
+  it("reports process-group permission failures instead of claiming cleanup", async () => {
+    const controller = new ManagedProcessController({ stopGraceMs: 20 });
+    const view = await controller.start({
+      executable: process.execPath,
+      args: ["--input-type=module", "--eval", "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);"],
+      cwd: process.cwd(),
+    });
+    const originalKill = process.kill.bind(process);
+    const denied = Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
+      if (pid === -(view.pgid ?? 0)) throw denied;
+      return originalKill(pid, signal as NodeJS.Signals);
+    }) as typeof process.kill);
+
+    try {
+      await expect(controller.stop(view.id)).resolves.toMatchObject({
+        state: "cleanup_failed",
+        stopReason: "explicit",
+        error: expect.stringContaining("EPERM"),
+      });
+    } finally {
+      killSpy.mockRestore();
+      if (view.pgid) {
+        try { originalKill(-view.pgid, "SIGKILL"); } catch { /* already gone */ }
+      }
+      await controller.shutdown();
+    }
+  });
+
+  it("rejects argument vectors above the total byte limit", async () => {
+    const controller = new ManagedProcessController();
+    await expect(controller.start({
+      executable: process.execPath,
+      args: ["x".repeat(70_000)],
+      cwd: process.cwd(),
+    })).rejects.toThrow("argument vector");
+    await controller.shutdown();
+  });
+
+  it("rejects invalid resource limits", () => {
+    expect(() => new ManagedProcessController({ maxActive: 0 })).toThrow("maxActive");
+    expect(() => new ManagedProcessController({ maxStreamBytes: 0 })).toThrow("maxStreamBytes");
+    expect(() => new ManagedProcessController({ maxOutputBytes: 0 })).toThrow("maxOutputBytes");
+    expect(() => new ManagedProcessController({ maxStreamBytes: 8, maxOutputBytes: 9 })).toThrow("maxOutputBytes");
+    expect(() => new ManagedProcessController({ maxRecords: 0 })).toThrow("maxRecords");
+    expect(() => new ManagedProcessController({ stopGraceMs: 0 })).toThrow("stopGraceMs");
+  });
+});

--- a/extensions/managed-process/controller.ts
+++ b/extensions/managed-process/controller.ts
@@ -1,0 +1,496 @@
+import {
+  spawn,
+  type ChildProcessByStdio,
+} from "node:child_process";
+import type { Readable } from "node:stream";
+
+const DEFAULT_MAX_ACTIVE = 8;
+const DEFAULT_STREAM_BYTES = 64 * 1024;
+const DEFAULT_OUTPUT_BYTES = 20 * 1024;
+const DEFAULT_MAX_RECORDS = 64;
+const DEFAULT_STOP_GRACE_MS = 750;
+const MAX_ARGUMENTS = 128;
+const MAX_ARGUMENT_BYTES = 8_000;
+const MAX_ARGUMENT_VECTOR_BYTES = 64 * 1024;
+const MAX_PATH_BYTES = 8_000;
+
+type ManagedChild = ChildProcessByStdio<null, Readable, Readable>;
+
+export type ManagedProcessState =
+  | "starting"
+  | "running"
+  | "stopping"
+  | "exited"
+  | "signaled"
+  | "start_failed"
+  | "cleanup_failed";
+
+export type ManagedProcessStopReason =
+  | "explicit"
+  | "session_shutdown"
+  | "leader_exit_cleanup"
+  | "startup_cancelled"
+  | "process_error";
+
+export interface StartProcessInput {
+  executable: string;
+  args?: string[];
+  cwd: string;
+  signal?: AbortSignal;
+}
+
+export interface ManagedProcessView {
+  id: number;
+  executable: string;
+  args: string[];
+  cwd: string;
+  pid?: number;
+  pgid?: number;
+  state: ManagedProcessState;
+  active: boolean;
+  startedAt: number;
+  endedAt?: number;
+  exitCode?: number;
+  exitSignal?: NodeJS.Signals;
+  stopReason?: ManagedProcessStopReason;
+  error?: string;
+}
+
+export interface StreamOutput {
+  text: string;
+  retainedBytes: number;
+  observedBytes: number;
+  truncated: boolean;
+}
+
+export interface ManagedProcessOutput {
+  id: number;
+  state: ManagedProcessState;
+  stdout: StreamOutput;
+  stderr: StreamOutput;
+}
+
+export interface ManagedProcessControllerOptions {
+  maxActive?: number;
+  maxStreamBytes?: number;
+  maxOutputBytes?: number;
+  maxRecords?: number;
+  stopGraceMs?: number;
+  now?: () => number;
+  onChange?: () => void;
+}
+
+function decodeTailWithin(buffer: Buffer, maximumBytes: number): string {
+  const decoded = buffer.toString("utf8");
+  let start = decoded.length;
+  let bytes = 0;
+  while (start > 0) {
+    let next = start - 1;
+    const code = decoded.charCodeAt(next);
+    if (code >= 0xdc00 && code <= 0xdfff && next > 0) next -= 1;
+    const characterBytes = Buffer.byteLength(decoded.slice(next, start), "utf8");
+    if (bytes + characterBytes > maximumBytes) break;
+    bytes += characterBytes;
+    start = next;
+  }
+  return decoded.slice(start);
+}
+
+class TailBuffer {
+  private value = Buffer.alloc(0);
+  private observed = 0;
+
+  constructor(private readonly limit: number) {}
+
+  append(chunk: Buffer): void {
+    this.observed += chunk.length;
+    if (chunk.length >= this.limit) {
+      this.value = Buffer.from(chunk.subarray(chunk.length - this.limit));
+      return;
+    }
+    const keepFromCurrent = Math.max(0, this.value.length + chunk.length - this.limit);
+    this.value = Buffer.concat([this.value.subarray(keepFromCurrent), chunk]);
+  }
+
+  snapshot(maxBytes = this.limit): StreamOutput {
+    const retained = this.value.subarray(Math.max(0, this.value.length - maxBytes));
+    const text = decodeTailWithin(retained, maxBytes);
+    const returnedBytes = Buffer.byteLength(text, "utf8");
+    return {
+      text,
+      retainedBytes: returnedBytes,
+      observedBytes: this.observed,
+      truncated: this.observed > returnedBytes,
+    };
+  }
+}
+
+interface ProcessRecord extends ManagedProcessView {
+  child: ManagedChild;
+  stdoutBuffer: TailBuffer;
+  stderrBuffer: TailBuffer;
+  startFailed: boolean;
+  cleanupErrors: string[];
+  forceKill?: NodeJS.Timeout;
+  forceClose?: NodeJS.Timeout;
+  pendingExitCode?: number | null;
+  pendingExitSignal?: NodeJS.Signals | null;
+  closed: Promise<void>;
+  resolveClosed: () => void;
+}
+
+type GroupProbe =
+  | { kind: "present" }
+  | { kind: "gone" }
+  | { kind: "failed"; error: string };
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function errorCode(error: unknown): string {
+  return typeof error === "object" && error !== null && "code" in error
+    ? String((error as { code?: unknown }).code ?? "unknown")
+    : "unknown";
+}
+
+function requirePositiveInteger(name: string, value: number): void {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`Managed process ${name} must be a positive integer.`);
+  }
+}
+
+function validateStart(input: StartProcessInput): void {
+  if (!input.executable.trim()) throw new Error("Executable must be a non-empty string.");
+  if (Buffer.byteLength(input.executable, "utf8") > MAX_PATH_BYTES) {
+    throw new Error(`Executable must not exceed ${MAX_PATH_BYTES} UTF-8 bytes.`);
+  }
+  if (Buffer.byteLength(input.cwd, "utf8") > MAX_PATH_BYTES) {
+    throw new Error(`Working directory must not exceed ${MAX_PATH_BYTES} UTF-8 bytes.`);
+  }
+  const args = input.args ?? [];
+  if (args.length > MAX_ARGUMENTS) {
+    throw new Error(`Managed process argument vector must contain at most ${MAX_ARGUMENTS} items.`);
+  }
+  let total = 0;
+  for (const arg of args) {
+    const bytes = Buffer.byteLength(arg, "utf8");
+    if (bytes > MAX_ARGUMENT_BYTES) {
+      throw new Error(`Managed process argument vector items must not exceed ${MAX_ARGUMENT_BYTES} UTF-8 bytes.`);
+    }
+    total += bytes;
+  }
+  if (total > MAX_ARGUMENT_VECTOR_BYTES) {
+    throw new Error(`Managed process argument vector must not exceed ${MAX_ARGUMENT_VECTOR_BYTES} UTF-8 bytes in total.`);
+  }
+}
+
+function probeGroup(pgid: number | undefined): GroupProbe {
+  if (!pgid) return { kind: "gone" };
+  try {
+    process.kill(-pgid, 0);
+    return { kind: "present" };
+  } catch (error) {
+    if (errorCode(error) === "ESRCH") return { kind: "gone" };
+    return {
+      kind: "failed",
+      error: `Process-group probe failed (${errorCode(error)}): ${message(error)}`,
+    };
+  }
+}
+
+function signalGroup(pgid: number | undefined, signal: NodeJS.Signals): GroupProbe {
+  if (!pgid) return { kind: "gone" };
+  try {
+    process.kill(-pgid, signal);
+    return { kind: "present" };
+  } catch (error) {
+    if (errorCode(error) === "ESRCH") return { kind: "gone" };
+    return {
+      kind: "failed",
+      error: `Process-group ${signal} failed (${errorCode(error)}): ${message(error)}`,
+    };
+  }
+}
+
+export class ManagedProcessController {
+  private readonly records = new Map<number, ProcessRecord>();
+  private readonly maxActive: number;
+  private readonly maxStreamBytes: number;
+  private readonly maxOutputBytes: number;
+  private readonly maxRecords: number;
+  private readonly stopGraceMs: number;
+  private readonly now: () => number;
+  private readonly onChange?: () => void;
+  private nextId = 1;
+  private shuttingDown = false;
+  private shutdownPromise?: Promise<void>;
+
+  constructor(options: ManagedProcessControllerOptions = {}) {
+    this.maxActive = options.maxActive ?? DEFAULT_MAX_ACTIVE;
+    this.maxStreamBytes = options.maxStreamBytes ?? DEFAULT_STREAM_BYTES;
+    this.maxOutputBytes = options.maxOutputBytes ?? DEFAULT_OUTPUT_BYTES;
+    this.maxRecords = options.maxRecords ?? DEFAULT_MAX_RECORDS;
+    this.stopGraceMs = options.stopGraceMs ?? DEFAULT_STOP_GRACE_MS;
+    requirePositiveInteger("maxActive", this.maxActive);
+    requirePositiveInteger("maxStreamBytes", this.maxStreamBytes);
+    requirePositiveInteger("maxOutputBytes", this.maxOutputBytes);
+    requirePositiveInteger("maxRecords", this.maxRecords);
+    requirePositiveInteger("stopGraceMs", this.stopGraceMs);
+    if (this.maxOutputBytes > this.maxStreamBytes) {
+      throw new Error("Managed process maxOutputBytes must not exceed maxStreamBytes.");
+    }
+    this.now = options.now ?? Date.now;
+    this.onChange = options.onChange;
+  }
+
+  list(): ManagedProcessView[] {
+    return [...this.records.values()].map((record) => this.view(record));
+  }
+
+  output(id: number, maxBytes = this.maxOutputBytes): ManagedProcessOutput {
+    if (!Number.isInteger(maxBytes) || maxBytes < 1 || maxBytes > this.maxOutputBytes) {
+      throw new Error(`Managed process output maxBytes must be an integer from 1 through ${this.maxOutputBytes}.`);
+    }
+    const record = this.require(id);
+    return {
+      id,
+      state: record.state,
+      stdout: record.stdoutBuffer.snapshot(maxBytes),
+      stderr: record.stderrBuffer.snapshot(maxBytes),
+    };
+  }
+
+  async start(input: StartProcessInput): Promise<ManagedProcessView> {
+    if (this.shuttingDown) throw new Error("The managed-process session is shutting down.");
+    if (process.platform === "win32") {
+      throw new Error("Managed processes require Unix process-group signaling and are not supported on Windows.");
+    }
+    validateStart(input);
+    if (input.signal?.aborted) throw new Error("Managed process start was cancelled before spawn acceptance.");
+    if ([...this.records.values()].filter((record) => record.active).length >= this.maxActive) {
+      throw new Error(`At most ${this.maxActive} managed processes may be active; no process was started.`);
+    }
+
+    const child = spawn(input.executable, input.args ?? [], {
+      cwd: input.cwd,
+      env: process.env,
+      shell: false,
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const id = this.nextId++;
+    let resolveClosed = () => {};
+    const closed = new Promise<void>((resolve) => {
+      resolveClosed = resolve;
+    });
+    const record: ProcessRecord = {
+      id,
+      executable: input.executable,
+      args: [...(input.args ?? [])],
+      cwd: input.cwd,
+      pid: child.pid,
+      pgid: child.pid,
+      state: "starting",
+      active: true,
+      startedAt: this.now(),
+      child,
+      stdoutBuffer: new TailBuffer(this.maxStreamBytes),
+      stderrBuffer: new TailBuffer(this.maxStreamBytes),
+      startFailed: false,
+      cleanupErrors: [],
+      closed,
+      resolveClosed,
+    };
+    this.records.set(id, record);
+    this.changed();
+
+    child.stdout.on("data", (chunk: Buffer) => record.stdoutBuffer.append(chunk));
+    child.stderr.on("data", (chunk: Buffer) => record.stderrBuffer.append(chunk));
+    child.once("exit", (code, signal) => {
+      record.pendingExitCode = code;
+      record.pendingExitSignal = signal;
+      if (!record.stopReason) this.beginTermination(record, "leader_exit_cleanup");
+    });
+    child.once("close", (code, signal) => {
+      record.pendingExitCode = code ?? record.pendingExitCode ?? null;
+      record.pendingExitSignal = signal ?? record.pendingExitSignal ?? null;
+      this.finishIfGroupGone(record);
+    });
+
+    return new Promise<ManagedProcessView>((resolve, reject) => {
+      let settledStart = false;
+      const cleanup = () => input.signal?.removeEventListener("abort", abort);
+      const abort = () => {
+        if (settledStart || !record.active) return;
+        settledStart = true;
+        record.startFailed = true;
+        record.error = "Managed process start was cancelled before spawn acceptance.";
+        cleanup();
+        this.beginTermination(record, "startup_cancelled");
+        reject(new Error(record.error));
+      };
+
+      input.signal?.addEventListener("abort", abort, { once: true });
+      child.once("spawn", () => {
+        if (settledStart) return;
+        settledStart = true;
+        cleanup();
+        if (this.shuttingDown || record.stopReason === "session_shutdown") {
+          record.startFailed = true;
+          record.error = "Managed process start was cancelled because session shutdown began before spawn acceptance.";
+          reject(new Error(record.error));
+          return;
+        }
+        record.state = "running";
+        this.changed();
+        resolve(this.view(record));
+      });
+      child.once("error", (error) => {
+        const text = `Failed to start ${input.executable}: ${message(error)}`;
+        if (!settledStart) {
+          settledStart = true;
+          record.startFailed = true;
+          record.error = text;
+          cleanup();
+          reject(new Error(text));
+          return;
+        }
+        record.cleanupErrors.push(`Managed child process error: ${message(error)}`);
+        this.beginTermination(record, "process_error");
+      });
+      if (input.signal?.aborted) abort();
+    });
+  }
+
+  async stop(id: number): Promise<ManagedProcessView> {
+    const record = this.require(id);
+    if (!record.active) return this.view(record);
+    this.beginTermination(record, "explicit");
+    await record.closed;
+    return this.view(record);
+  }
+
+  shutdown(): Promise<void> {
+    if (this.shutdownPromise) return this.shutdownPromise;
+    this.shuttingDown = true;
+    this.shutdownPromise = (async () => {
+      const active = [...this.records.values()].filter((record) => record.active);
+      for (const record of active) this.beginTermination(record, "session_shutdown");
+      await Promise.allSettled(active.map((record) => record.closed));
+      this.records.clear();
+      this.changed();
+    })();
+    return this.shutdownPromise;
+  }
+
+  private beginTermination(record: ProcessRecord, reason: ManagedProcessStopReason): void {
+    if (!record.active) return;
+    record.stopReason ??= reason;
+    if (record.state !== "starting") record.state = "stopping";
+    this.captureCleanupFailure(record, signalGroup(record.pgid, "SIGTERM"));
+    record.forceKill ??= setTimeout(() => {
+      this.captureCleanupFailure(record, signalGroup(record.pgid, "SIGKILL"));
+      record.child.stdout.destroy();
+      record.child.stderr.destroy();
+      this.awaitGroupCleanup(record, Date.now() + Math.max(500, this.stopGraceMs));
+    }, this.stopGraceMs);
+    this.changed();
+  }
+
+  private awaitGroupCleanup(record: ProcessRecord, deadline: number): void {
+    if (!record.active) return;
+    const probe = probeGroup(record.pgid);
+    const hasOutcome = record.pendingExitCode !== undefined || record.pendingExitSignal !== undefined;
+    if (probe.kind === "gone" && hasOutcome) {
+      this.finish(record);
+      return;
+    }
+    if (Date.now() >= deadline) {
+      this.captureCleanupFailure(record, probe);
+      if (probe.kind === "present") {
+        record.cleanupErrors.push("Managed process group remained alive after SIGKILL escalation.");
+      }
+      if (!hasOutcome) {
+        record.cleanupErrors.push("Managed process leader did not report a terminal outcome before the cleanup deadline.");
+      }
+      this.finish(record);
+      return;
+    }
+    record.forceClose = setTimeout(() => this.awaitGroupCleanup(record, deadline), 25);
+  }
+
+  private finishIfGroupGone(record: ProcessRecord): void {
+    if (!record.active) return;
+    const probe = probeGroup(record.pgid);
+    if (probe.kind === "gone") {
+      this.finish(record);
+    }
+  }
+
+  private captureCleanupFailure(record: ProcessRecord, probe: GroupProbe): void {
+    if (probe.kind === "failed" && !record.cleanupErrors.includes(probe.error)) {
+      record.cleanupErrors.push(probe.error);
+    }
+  }
+
+  private finish(record: ProcessRecord): void {
+    if (!record.active) return;
+    if (record.forceKill) clearTimeout(record.forceKill);
+    if (record.forceClose) clearTimeout(record.forceClose);
+    record.active = false;
+    record.endedAt = this.now();
+    if (record.cleanupErrors.length > 0) {
+      record.state = "cleanup_failed";
+      record.error = record.cleanupErrors.join(" ");
+    } else if (record.startFailed) {
+      record.state = "start_failed";
+    } else if (record.pendingExitSignal) {
+      record.state = "signaled";
+      record.exitSignal = record.pendingExitSignal;
+    } else {
+      record.state = "exited";
+      record.exitCode = record.pendingExitCode ?? undefined;
+    }
+    record.resolveClosed();
+    this.trimHistory();
+    this.changed();
+  }
+
+  private trimHistory(): void {
+    while (this.records.size > this.maxRecords) {
+      const oldestTerminal = [...this.records.values()].find((record) => !record.active);
+      if (!oldestTerminal) return;
+      this.records.delete(oldestTerminal.id);
+    }
+  }
+
+  private require(id: number): ProcessRecord {
+    const record = this.records.get(id);
+    if (!record) throw new Error(`Unknown managed process ID: ${id}.`);
+    return record;
+  }
+
+  private view(record: ProcessRecord): ManagedProcessView {
+    return {
+      id: record.id,
+      executable: record.executable,
+      args: [...record.args],
+      cwd: record.cwd,
+      pid: record.pid,
+      pgid: record.pgid,
+      state: record.state,
+      active: record.active,
+      startedAt: record.startedAt,
+      endedAt: record.endedAt,
+      exitCode: record.exitCode,
+      exitSignal: record.exitSignal,
+      stopReason: record.stopReason,
+      error: record.error,
+    };
+  }
+
+  private changed(): void {
+    this.onChange?.();
+  }
+}

--- a/extensions/managed-process/index.test.ts
+++ b/extensions/managed-process/index.test.ts
@@ -43,6 +43,18 @@ describe("managed-process extension", () => {
     for (const boundary of ["without a shell", "inherits", "credentials", "loopback", "stdin", "TTY", "session-scoped", "process group"]) {
       expect(discovery).toContain(boundary);
     }
+    for (const intent of [
+      "whenever the current task genuinely requires",
+      "No separate confirmation is required",
+      "Expected lifecycle, not elapsed seconds",
+      "direct helpers",
+      "One concrete bounded output/list snapshot or readiness probe",
+      "later snapshots",
+      "no longer needed",
+      "fallback",
+    ]) {
+      expect(discovery).toContain(intent);
+    }
 
     await handlers.get("session_start")?.({}, ctx);
     const start = await tools[0].execute("start-1", {

--- a/extensions/managed-process/index.test.ts
+++ b/extensions/managed-process/index.test.ts
@@ -1,0 +1,65 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { registerManagedProcessExtension } from "./index.ts";
+
+interface RegisteredTool {
+  name: string;
+  description: string;
+  promptGuidelines?: string[];
+  execute(
+    id: string,
+    params: Record<string, unknown>,
+    signal: AbortSignal | undefined,
+    onUpdate: undefined,
+    ctx: ExtensionContext,
+  ): Promise<{ content: Array<{ type: string; text: string }>; details?: unknown }>;
+}
+
+describe("managed-process extension", () => {
+  it("exposes explicit session-scoped lifecycle tools and cleans up on shutdown", async () => {
+    const tools: RegisteredTool[] = [];
+    const handlers = new Map<string, (...args: unknown[]) => unknown>();
+    const statuses: Array<string | undefined> = [];
+    const pi = {
+      registerTool: (tool: RegisteredTool) => tools.push(tool),
+      on: (event: string, handler: (...args: unknown[]) => unknown) => handlers.set(event, handler),
+    } as unknown as ExtensionAPI;
+    const ctx = {
+      cwd: process.cwd(),
+      ui: {
+        theme: { fg: (_color: string, text: string) => text },
+        setStatus: (_key: string, value: string | undefined) => statuses.push(value),
+      },
+    } as unknown as ExtensionContext;
+
+    registerManagedProcessExtension(pi);
+    expect(tools.map((tool) => tool.name)).toEqual([
+      "managed_process_start",
+      "managed_process_list",
+      "managed_process_output",
+      "managed_process_stop",
+    ]);
+    const discovery = tools.flatMap((tool) => [tool.description, ...(tool.promptGuidelines ?? [])]).join(" ");
+    for (const boundary of ["without a shell", "inherits", "credentials", "loopback", "stdin", "TTY", "session-scoped", "process group"]) {
+      expect(discovery).toContain(boundary);
+    }
+
+    await handlers.get("session_start")?.({}, ctx);
+    const start = await tools[0].execute("start-1", {
+      executable: process.execPath,
+      args: ["--input-type=module", "--eval", "process.stdout.write('ready\\n'); setInterval(() => {}, 1000);"],
+    }, undefined, undefined, ctx);
+    expect(start.content[0].text).toContain("started");
+    expect(statuses).toContain("managed processes: 1");
+
+    const list = await tools[1].execute("list-1", {}, undefined, undefined, ctx);
+    expect(list.content[0].text).toContain("#1 running");
+    expect(list.content[0].text).toContain("started:");
+    await expect.poll(async () => (await tools[2].execute("output-1", { id: 1 }, undefined, undefined, ctx)).content[0].text).toContain("ready");
+
+    const stop = await tools[3].execute("stop-1", { id: 1 }, undefined, undefined, ctx);
+    expect(stop.content[0].text).toMatch(/#1 (exited|signaled)/);
+    await handlers.get("session_shutdown")?.({}, ctx);
+    expect(statuses.at(-1)).toBeUndefined();
+  });
+});

--- a/extensions/managed-process/index.ts
+++ b/extensions/managed-process/index.ts
@@ -125,10 +125,10 @@ export function registerManagedProcessExtension(
     description: "Start a session-scoped long-running process from an executable plus literal arguments and cwd, without a shell. Returns after spawn acceptance instead of waiting for completion. The child inherits the Pi process environment, which may include credentials; stdin is ignored and no interactive TTY is allocated. On Unix the extension owns a process group for bounded stop and shutdown cleanup. It does not sandbox network access or force servers to bind loopback.",
     promptSnippet: "Start a session-scoped long-running server, watcher, tail, or development process",
     promptGuidelines: [
-      "Use managed_process_start only for commands expected to remain active; use ordinary bash for finite commands.",
-      "Before managed_process_start, inspect the executable, literal arguments, cwd, inherited-environment needs, stdin or TTY assumptions, and network binding options without exposing credential values; prefer a verified absolute executable path.",
+      "Use managed_process_start whenever the current task genuinely requires a long-running local process that would otherwise block a synchronous tool call, such as a server, watcher, tail, or development process. No separate confirmation is required merely because it runs in the background when it remains within the user's existing task authorization and safety constraints. Expected lifecycle, not elapsed seconds, distinguishes managed processes from finite commands; use ordinary bash for finite commands.",
+      "Before managed_process_start, inspect the executable, its direct helpers, literal arguments, cwd, inherited-environment needs, stdin or TTY assumptions, and network binding options without exposing credential values; prefer a verified absolute executable path.",
       "managed_process_start does not enforce loopback binding or sandbox network access; pass an application's verified loopback option when network exposure matters.",
-      "After managed_process_start accepts a process, do not wait, sleep, or repeatedly poll. Continue independent work; use managed_process_output or managed_process_list only when a concrete snapshot is needed.",
+      "After managed_process_start accepts a process, do not wait, sleep, or repeatedly poll. Continue independent work. One concrete bounded output/list snapshot or readiness probe is allowed when needed; later snapshots require a real diagnostic or decision need rather than waiting for change.",
     ],
     parameters: StartSchema,
     async execute(_id, params: StartParams, signal, _onUpdate, ctx) {
@@ -190,6 +190,9 @@ export function registerManagedProcessExtension(
     name: "managed_process_stop",
     label: "Stop Managed Process",
     description: "Explicitly stop a known session-scoped managed process. On Unix this terminates its owned process group with SIGTERM and bounded SIGKILL escalation; a process that deliberately creates a new session or process group may escape that OS mechanism. Repeating stop for a known terminal process is safe.",
+    promptGuidelines: [
+      "Use managed_process_stop once a managed process is no longer needed. Session-shutdown cleanup is a fallback, not a reason to leave unnecessary processes active.",
+    ],
     parameters: StopSchema,
     async execute(_id, params) {
       const view = await controller.stop(params.id);

--- a/extensions/managed-process/index.ts
+++ b/extensions/managed-process/index.ts
@@ -1,0 +1,214 @@
+import { resolve } from "node:path";
+import {
+  keyHint,
+  truncateHead,
+  type AgentToolResult,
+  type ExtensionAPI,
+  type ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import { Type, type Static } from "typebox";
+import {
+  ManagedProcessController,
+  type ManagedProcessControllerOptions,
+  type ManagedProcessOutput,
+  type ManagedProcessView,
+} from "./controller.ts";
+
+const MAX_ARGUMENTS = 128;
+const MAX_ARGUMENT_CHARACTERS = 8_000;
+const MAX_OUTPUT_BYTES = 20 * 1024;
+
+const IdSchema = Type.Integer({ minimum: 1, description: "Session-local managed process ID." });
+const StartSchema = Type.Object({
+  executable: Type.String({
+    minLength: 1,
+    maxLength: MAX_ARGUMENT_CHARACTERS,
+    description: "Executable path or command resolved through PATH and started directly without a shell.",
+  }),
+  args: Type.Optional(Type.Array(Type.String({ maxLength: MAX_ARGUMENT_CHARACTERS }), {
+    maxItems: MAX_ARGUMENTS,
+    description: "Literal argument vector. Shell expansion, quoting, pipes, redirects, and interpolation do not occur.",
+  })),
+  cwd: Type.Optional(Type.String({
+    minLength: 1,
+    maxLength: MAX_ARGUMENT_CHARACTERS,
+    description: "Working directory resolved from the Pi session cwd; defaults to that cwd.",
+  })),
+}, { additionalProperties: false });
+const ListSchema = Type.Object({}, { additionalProperties: false });
+const OutputSchema = Type.Object({
+  id: IdSchema,
+  maxBytes: Type.Optional(Type.Integer({
+    minimum: 1,
+    maximum: MAX_OUTPUT_BYTES,
+    description: "Maximum recent bytes returned from each stream; defaults to 20,480.",
+  })),
+}, { additionalProperties: false });
+const StopSchema = Type.Object({ id: IdSchema }, { additionalProperties: false });
+
+type StartParams = Static<typeof StartSchema>;
+type OutputParams = Static<typeof OutputSchema>;
+
+export interface ManagedProcessExtensionOptions extends ManagedProcessControllerOptions {}
+
+function compact(value: string, maximumCharacters: number): string {
+  return value.length <= maximumCharacters
+    ? value
+    : `${value.slice(0, maximumCharacters - 1)}…`;
+}
+
+function commandText(view: ManagedProcessView): string {
+  const shown = [view.executable, ...view.args.slice(0, 8)]
+    .map((part) => JSON.stringify(compact(part, 160)));
+  if (view.args.length > 8) shown.push(`[${view.args.length - 8} more arguments]`);
+  return compact(shown.join(" "), 1_600);
+}
+
+function viewText(view: ManagedProcessView): string {
+  const outcome = view.exitCode !== undefined
+    ? ` · exit ${view.exitCode}`
+    : view.exitSignal
+      ? ` · signal ${view.exitSignal}`
+      : "";
+  const error = view.error ? ` · error: ${compact(view.error, 240)}` : "";
+  const processIds = view.pid === undefined ? "" : ` · pid ${view.pid} · pgid ${view.pgid}`;
+  const stopReason = view.stopReason ? `\n  stop reason: ${view.stopReason}` : "";
+  const ended = view.endedAt === undefined ? "" : `\n  ended: ${new Date(view.endedAt).toISOString()}`;
+  return `#${view.id} ${view.state}${outcome}${processIds}${error}\n  ${commandText(view)}\n  cwd: ${JSON.stringify(compact(view.cwd, 320))}\n  started: ${new Date(view.startedAt).toISOString()}${ended}${stopReason}`;
+}
+
+function streamText(name: "stdout" | "stderr", stream: ManagedProcessOutput[typeof name]): string {
+  const dropped = stream.truncated
+    ? `; earlier bytes omitted (${stream.observedBytes} observed)`
+    : `; ${stream.observedBytes} observed`;
+  return `${name} (${stream.retainedBytes} returned bytes${dropped}):\n${stream.text || "[no output]"}`;
+}
+
+function listText(views: ManagedProcessView[]): string {
+  if (views.length === 0) return "No managed processes are known in this Pi session.";
+  const result = truncateHead(views.map(viewText).join("\n"), { maxBytes: 48_000, maxLines: 1_000 });
+  return result.truncated
+    ? `${result.content}\n[Managed process list truncated to 48,000 bytes.]`
+    : result.content;
+}
+
+function outputText(output: ManagedProcessOutput): string {
+  return [
+    `Managed process #${output.id} ${output.state}.`,
+    streamText("stdout", output.stdout),
+    streamText("stderr", output.stderr),
+  ].join("\n\n");
+}
+
+function resultText(result: AgentToolResult<unknown>): string {
+  return result.content.map((item) => item.type === "text" ? item.text : "[Non-text output omitted.]").join("\n");
+}
+
+export function registerManagedProcessExtension(
+  pi: ExtensionAPI,
+  options: ManagedProcessExtensionOptions = {},
+): void {
+  let ui: ExtensionContext["ui"] | undefined;
+  let controller: ManagedProcessController;
+  const refreshUi = () => {
+    if (!ui) return;
+    const active = controller.list().filter((view) => view.active).length;
+    const status = active > 0 ? `managed processes: ${active}` : undefined;
+    ui.setStatus("managed-process", status ? ui.theme.fg("success", status) : undefined);
+  };
+  controller = new ManagedProcessController({ ...options, onChange: refreshUi });
+
+  pi.registerTool({
+    name: "managed_process_start",
+    label: "Start Managed Process",
+    description: "Start a session-scoped long-running process from an executable plus literal arguments and cwd, without a shell. Returns after spawn acceptance instead of waiting for completion. The child inherits the Pi process environment, which may include credentials; stdin is ignored and no interactive TTY is allocated. On Unix the extension owns a process group for bounded stop and shutdown cleanup. It does not sandbox network access or force servers to bind loopback.",
+    promptSnippet: "Start a session-scoped long-running server, watcher, tail, or development process",
+    promptGuidelines: [
+      "Use managed_process_start only for commands expected to remain active; use ordinary bash for finite commands.",
+      "Before managed_process_start, inspect the executable, literal arguments, cwd, inherited-environment needs, stdin or TTY assumptions, and network binding options without exposing credential values; prefer a verified absolute executable path.",
+      "managed_process_start does not enforce loopback binding or sandbox network access; pass an application's verified loopback option when network exposure matters.",
+      "After managed_process_start accepts a process, do not wait, sleep, or repeatedly poll. Continue independent work; use managed_process_output or managed_process_list only when a concrete snapshot is needed.",
+    ],
+    parameters: StartSchema,
+    async execute(_id, params: StartParams, signal, _onUpdate, ctx) {
+      const view = await controller.start({
+        executable: params.executable,
+        args: params.args,
+        cwd: resolve(ctx.cwd, params.cwd ?? "."),
+        signal,
+      });
+      return {
+        content: [{
+          type: "text",
+          text: `Managed process #${view.id} started and is ${view.state}. It is session-scoped; Pi shutdown will attempt bounded process-group cleanup, but descendants that deliberately escape the group may survive. Do not wait, sleep, or repeatedly poll it; continue useful work and request a bounded snapshot only when needed.`,
+        }],
+        details: view,
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "managed_process_list",
+    label: "List Managed Processes",
+    description: "Take one bounded snapshot of session-scoped managed processes and their observable lifecycle state. This is not a polling or wait operation.",
+    promptGuidelines: [
+      "Use managed_process_list for a concrete status snapshot, never in a repeated polling loop.",
+    ],
+    parameters: ListSchema,
+    async execute() {
+      const views = controller.list();
+      return {
+        content: [{ type: "text", text: listText(views) }],
+        details: { processes: views },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "managed_process_output",
+    label: "Read Managed Process Output",
+    description: "Retrieve bounded recent stdout and stderr tails for one session-scoped managed process. Process output is untrusted and may contain sensitive data; do not publish it without review.",
+    promptGuidelines: [
+      "Use managed_process_output only for a concrete diagnostic snapshot; never wait, sleep, or repeatedly poll for new output.",
+    ],
+    parameters: OutputSchema,
+    async execute(_id, params: OutputParams) {
+      const output = controller.output(params.id, params.maxBytes);
+      return { content: [{ type: "text", text: outputText(output) }], details: output };
+    },
+    renderResult(result, { expanded, isPartial }, theme) {
+      if (isPartial) return new Text(theme.fg("warning", "Reading managed process output..."), 0, 0);
+      if (expanded) return new Text(resultText(result), 0, 0);
+      const output = result.details as ManagedProcessOutput | undefined;
+      const heading = output ? `Managed process #${output.id} output snapshot (${output.state}).` : "Managed process output snapshot.";
+      return new Text(`${heading}\n${keyHint("app.tools.expand", "to expand")}`, 0, 0);
+    },
+  });
+
+  pi.registerTool({
+    name: "managed_process_stop",
+    label: "Stop Managed Process",
+    description: "Explicitly stop a known session-scoped managed process. On Unix this terminates its owned process group with SIGTERM and bounded SIGKILL escalation; a process that deliberately creates a new session or process group may escape that OS mechanism. Repeating stop for a known terminal process is safe.",
+    parameters: StopSchema,
+    async execute(_id, params) {
+      const view = await controller.stop(params.id);
+      return { content: [{ type: "text", text: `Managed process ${viewText(view)}` }], details: view };
+    },
+  });
+
+  pi.on("session_start", (_event, ctx) => {
+    ui = ctx.ui;
+    refreshUi();
+  });
+
+  pi.on("session_shutdown", async () => {
+    await controller.shutdown();
+    ui?.setStatus("managed-process", undefined);
+    ui = undefined;
+  });
+}
+
+export default function managedProcessExtension(pi: ExtensionAPI): void {
+  registerManagedProcessExtension(pi);
+}

--- a/justfile
+++ b/justfile
@@ -21,6 +21,10 @@ orchestrate:
 scheduler:
     pi --no-skills --no-extensions --extension "${HOME}/.pi/agent/extensions/exit-alias.ts" --extension ./extensions/scheduler/index.ts --no-prompt-templates --no-context-files --append-system-prompt ./AGENTS.md
 
+# Start Pi with the session-scoped managed-process extension and the exit alias
+managed-processes:
+    pi --no-skills --no-extensions --extension "${HOME}/.pi/agent/extensions/exit-alias.ts" --extension ./extensions/managed-process/index.ts --no-prompt-templates --no-context-files --append-system-prompt ./AGENTS.md
+
 # Start Pi with the asynchronous subagent extension and the exit alias
 subagents:
     pi --no-skills --no-extensions --extension "${HOME}/.pi/agent/extensions/exit-alias.ts" --extension ./extensions/subagents/index.ts --no-prompt-templates --no-context-files --append-system-prompt ./AGENTS.md


### PR DESCRIPTION
## Summary

- add an opt-in session-scoped manager for long-running local processes
- expose shell-free start, bounded list/output snapshots, and explicit process-group stop tools
- enforce bounded concurrency, history, argument vectors, stream tails, and cleanup deadlines
- document inherited authority, network/TTY limits, Unix ownership, escaped descendants, and Windows rejection
- add deterministic lifecycle, process-group, race, failure, and output-bound tests

## Verification

- `npm test` (93 tests)
- `npm run typecheck`
- `just --list`
- `just --dry-run managed-processes`
- `git diff --check`

Closes #17
