### PR TITLE
feat(subagents): inherit active capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,8 +416,11 @@ dispatched. An explicit `model` override must use the qualified
 `provider/model` form; bare or malformed values are rejected before child
 launch. Optional `model` and `reasoning` overrides apply to one dispatch only
 and must be supplied only when the user explicitly requests that routing. The
-live subagent widget and `/sublist` output show the effective routing values. For
-example:
+live subagent widget and `/sublist` output show the effective routing values.
+At each start or continuation, omitted `tools` inherit the parent's full
+then-active set, including extension tools; an explicit array can only narrow
+that snapshot, and `tools: []` selects no tools. A subagent name is descriptive
+and does not silently change capabilities. For example:
 
 ```text
 /sub Inspect the authentication flow and report risks.
@@ -429,11 +432,19 @@ example:
 /sublist
 ```
 
-Subagents inherit the current environment, including credentials and SSH agent
-access. They are not sandboxed. Child extensions are disabled, only the user's
-Pi skills directory is loaded, and at most twelve child processes run at once.
-The registry is intentionally in memory; native Pi JSONL sessions remain after
-the orchestrator exits.
+Subagents inherit the current environment and working directory, including
+credentials and SSH agent access. They are not sandboxed. Broad child extension
+discovery is disabled; Pi loads only the extension providers required for the
+inherited tools and verifies the exact tool/provider set before accepting the
+prompt. Normal skill and repository-instruction discovery still applies from
+the child working directory.
+
+A fresh child stores only its explicit prompt in a new native Pi JSONL
+conversation; it never imports the parent transcript, summaries, or hidden
+continuation state. Continuation resumes only that child's conversation while
+capturing the parent's current capabilities again. At most twelve child
+processes run at once. The registry is intentionally in memory; native Pi JSONL
+sessions remain after the orchestrator exits.
 
 Install dependencies and verify the extension with:
 

--- a/docs/subagents/CONTEXT.md
+++ b/docs/subagents/CONTEXT.md
@@ -12,9 +12,17 @@ _Avoid_: Product, service, platform, mechanical controller
 An independent Pi agent conversation started by the orchestrator agent and owned by its current session. Its conversation persists across turns, while its process exists only during an active turn.
 _Avoid_: Worker service, task, job
 
+**Inherited runtime baseline**:
+The orchestrator's active operating environment projected into a subagent by default: active Pi and extension tools, the extension providers required to reproduce those tools, normal skill discovery, applicable repository instructions, working directory, routing defaults, and environment. Inheritance is launch mechanics rather than a model-visible negotiation tool. Explicit caller restrictions are opt-in; omission means inherit the baseline.
+_Avoid_: Conversation fork, ambient extension discovery, role profile, inheritance prompt
+
+**Capability snapshot**:
+The exact set of tools active in the orchestrator when a start or continuation dispatch is accepted. A subagent inherits this snapshot by default, including extension tools, without gaining inactive or undiscovered tools. The caller may explicitly narrow the snapshot; assigning a writer, reviewer, or other name does not silently change it. Required provider loading and validation happen mechanically before prompt acceptance.
+_Avoid_: Installed tool catalog, role profile, automatic capability discovery
+
 **Clean start**:
-A new subagent conversation that receives its explicit prompt but none of the orchestrator conversation history.
-_Avoid_: Context fork, implicit inheritance
+A new subagent conversation that receives the inherited runtime baseline and its explicit prompt but none of the orchestrator transcript, compaction summary, hidden continuation state, or prior messages. A continuation preserves only that subagent's native Pi conversation; runtime inheritance never implies conversation sharing.
+_Avoid_: Context fork, implicit transcript inheritance, automatic conversation sharing
 
 **Subagent extension**:
 The mechanical Pi extension that connects the orchestrator agent to subagents and owns their process lifecycle, message transport, and status for the current session. It does not decide or interpret delegated work.

--- a/extensions/subagents/capabilities.test.ts
+++ b/extensions/subagents/capabilities.test.ts
@@ -1,0 +1,103 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import {
+  BUILTIN_TOOL_PROVIDER,
+  assertCapabilityMatch,
+  captureCapabilities,
+} from "./capabilities.ts";
+
+function setupCapabilities(active: string[], tools: Array<{ name: string; source: string; path: string }>) {
+  return {
+    getActiveTools: () => [...active],
+    getAllTools: () => tools.map((tool) => ({
+      name: tool.name,
+      description: `${tool.name} description`,
+      parameters: {},
+      sourceInfo: {
+        source: tool.source,
+        path: tool.path,
+        scope: "temporary",
+        origin: "top-level",
+      },
+    })),
+  } as unknown as ExtensionAPI;
+}
+
+describe("subagent capability snapshots", () => {
+  it("captures active built-in and extension tools with the required provider", () => {
+    const pi = setupCapabilities(
+      ["read", "browser_fetch"],
+      [
+        { name: "read", source: "builtin", path: "<builtin:read>" },
+        { name: "write", source: "builtin", path: "<builtin:write>" },
+        { name: "browser_fetch", source: "cli", path: "/extensions/browser-fetch/index.ts" },
+      ],
+    );
+
+    expect(captureCapabilities(pi)).toEqual({
+      tools: [
+        { name: "read", provider: BUILTIN_TOOL_PROVIDER },
+        { name: "browser_fetch", provider: "/extensions/browser-fetch/index.ts" },
+      ],
+      extensionPaths: ["/extensions/browser-fetch/index.ts"],
+    });
+  });
+
+  it("allows restrictions to keep only parent-active tools, including none", () => {
+    const pi = setupCapabilities(
+      ["read", "browser_fetch"],
+      [
+        { name: "read", source: "builtin", path: "<builtin:read>" },
+        { name: "browser_fetch", source: "cli", path: "/extensions/browser-fetch/index.ts" },
+      ],
+    );
+
+    expect(captureCapabilities(pi, ["read", "read"]).tools).toEqual([
+      { name: "read", provider: BUILTIN_TOOL_PROVIDER },
+    ]);
+    expect(captureCapabilities(pi, [])).toEqual({ tools: [], extensionPaths: [] });
+    expect(() => captureCapabilities(pi, ["write"])).toThrow(
+      "Restrictions can only keep tools active in the parent. Unavailable: write.",
+    );
+  });
+
+  it("bounds diagnostics when many restrictions are unavailable", () => {
+    const pi = setupCapabilities([], []);
+    const unavailable = Array.from({ length: 12 }, (_, index) => `missing_${index + 1}`);
+
+    expect(() => captureCapabilities(pi, unavailable)).toThrow(
+      "Unavailable: missing_1, missing_2, missing_3, missing_4, missing_5, missing_6, missing_7, missing_8, and 4 more.",
+    );
+  });
+
+  it("rejects an active tool whose provider cannot be loaded", () => {
+    const pi = setupCapabilities(
+      ["sdk_tool"],
+      [{ name: "sdk_tool", source: "sdk", path: "<sdk:sdk_tool>" }],
+    );
+
+    expect(() => captureCapabilities(pi)).toThrow(
+      'Active tool "sdk_tool" cannot be inherited because provider "<sdk:sdk_tool>" is not a loadable extension path.',
+    );
+  });
+
+  it("diagnoses missing, unexpected, and wrong-provider child capabilities", () => {
+    const promised = {
+      tools: [
+        { name: "read", provider: BUILTIN_TOOL_PROVIDER },
+        { name: "browser_fetch", provider: "/expected/browser.ts" },
+      ],
+      extensionPaths: ["/expected/browser.ts"],
+    };
+
+    expect(() => assertCapabilityMatch(promised, {
+      tools: [
+        { name: "read", provider: "/wrong/read.ts" },
+        { name: "extra", provider: BUILTIN_TOOL_PROVIDER },
+      ],
+      extensionPaths: [],
+    })).toThrow(
+      "read (expected builtin, got /wrong/read.ts); browser_fetch (expected /expected/browser.ts, missing); unexpected extra (builtin)",
+    );
+  });
+});

--- a/extensions/subagents/capabilities.test.ts
+++ b/extensions/subagents/capabilities.test.ts
@@ -81,6 +81,26 @@ describe("subagent capability snapshots", () => {
     );
   });
 
+  it("bounds an unloadable provider in diagnostics", () => {
+    const provider = `<inline:${"x".repeat(1_000)}>`;
+    const pi = setupCapabilities(
+      ["sdk_tool"],
+      [{ name: "sdk_tool", source: "sdk", path: provider }],
+    );
+
+    let captured: unknown;
+    try {
+      captureCapabilities(pi);
+    } catch (error) {
+      captured = error;
+    }
+
+    expect(captured).toBeInstanceOf(Error);
+    expect((captured as Error).message).toContain("…\" is not a loadable extension path");
+    expect((captured as Error).message).not.toContain(provider);
+    expect((captured as Error).message.length).toBeLessThan(400);
+  });
+
   it("diagnoses missing, unexpected, and wrong-provider child capabilities", () => {
     const promised = {
       tools: [

--- a/extensions/subagents/capabilities.ts
+++ b/extensions/subagents/capabilities.ts
@@ -1,0 +1,176 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export const BUILTIN_TOOL_PROVIDER = "builtin";
+export const CAPABILITY_PROBE_STATUS_KEY = "ompi:subagent-capabilities:v1";
+
+const MAX_TOOLS = 256;
+const MAX_TOOL_NAME_LENGTH = 256;
+const MAX_PROVIDER_LENGTH = 8_000;
+const MAX_PROBE_LENGTH = MAX_TOOLS * (MAX_TOOL_NAME_LENGTH + MAX_PROVIDER_LENGTH + 64);
+const MAX_DIAGNOSTIC_PROBLEMS = 8;
+const MAX_DIAGNOSTIC_VALUE_LENGTH = 256;
+
+export interface ToolCapability {
+  readonly name: string;
+  readonly provider: string;
+}
+
+export interface CapabilitySnapshot {
+  readonly tools: readonly ToolCapability[];
+  readonly extensionPaths: readonly string[];
+}
+
+function unique(values: readonly string[]): string[] {
+  return [...new Set(values)];
+}
+
+function assertBounded(value: string, label: string, limit: number): void {
+  if (value.length === 0 || value.length > limit) {
+    throw new Error(`${label} must contain between 1 and ${limit} characters.`);
+  }
+}
+
+function formatBoundedList(values: readonly string[]): string {
+  const visible = values.slice(0, MAX_DIAGNOSTIC_PROBLEMS);
+  const suffix = values.length > visible.length ? `, and ${values.length - visible.length} more` : "";
+  return `${visible.join(", ")}${suffix}`;
+}
+
+function diagnosticValue(value: string): string {
+  return value.length <= MAX_DIAGNOSTIC_VALUE_LENGTH
+    ? value
+    : `${value.slice(0, MAX_DIAGNOSTIC_VALUE_LENGTH - 1)}…`;
+}
+
+function loadableProvider(tool: ReturnType<ExtensionAPI["getAllTools"]>[number]): string {
+  if (tool.sourceInfo.source === "builtin") return BUILTIN_TOOL_PROVIDER;
+  const provider = tool.sourceInfo.path;
+  if (tool.sourceInfo.source === "sdk" || provider.startsWith("<")) {
+    throw new Error(
+      `Active tool "${tool.name}" cannot be inherited because provider "${provider}" is not a loadable extension path.`,
+    );
+  }
+  assertBounded(provider, `Provider for active tool "${tool.name}"`, MAX_PROVIDER_LENGTH);
+  return provider;
+}
+
+export function captureCapabilities(pi: ExtensionAPI, restrictions?: string[]): CapabilitySnapshot {
+  const active = unique(pi.getActiveTools());
+  const selected = restrictions === undefined ? active : unique(restrictions);
+  if (selected.length > MAX_TOOLS) {
+    throw new Error(`At most ${MAX_TOOLS} active tools can be inherited by one subagent dispatch.`);
+  }
+
+  for (const name of selected) assertBounded(name, "Tool name", MAX_TOOL_NAME_LENGTH);
+  const activeSet = new Set(active);
+  const unavailable = selected.filter((name) => !activeSet.has(name));
+  if (unavailable.length > 0) {
+    throw new Error(
+      `Restrictions can only keep tools active in the parent. Unavailable: ${formatBoundedList(unavailable)}.`,
+    );
+  }
+
+  const configured = new Map(pi.getAllTools().map((tool) => [tool.name, tool]));
+  const tools = selected.map((name): ToolCapability => {
+    const tool = configured.get(name);
+    if (!tool) {
+      throw new Error(`Parent capability mismatch: active tool "${name}" has no registered provider.`);
+    }
+    return { name, provider: loadableProvider(tool) };
+  });
+  const extensionPaths = unique(
+    tools
+      .map((tool) => tool.provider)
+      .filter((provider) => provider !== BUILTIN_TOOL_PROVIDER),
+  );
+  return { tools, extensionPaths };
+}
+
+export function cloneCapabilities(snapshot: CapabilitySnapshot): CapabilitySnapshot {
+  return {
+    tools: snapshot.tools.map((tool) => ({ ...tool })),
+    extensionPaths: [...snapshot.extensionPaths],
+  };
+}
+
+export function parseCapabilityProbe(value: unknown): CapabilitySnapshot {
+  if (typeof value !== "string" || value.length === 0 || value.length > MAX_PROBE_LENGTH) {
+    throw new Error("Child capability probe returned an invalid bounded payload.");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch (error) {
+    throw new Error("Child capability probe returned invalid JSON.", { cause: error });
+  }
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("Child capability probe returned an invalid snapshot.");
+  }
+  const report = parsed as { version?: unknown; tools?: unknown };
+  if (report.version !== 1 || !Array.isArray(report.tools) || report.tools.length > MAX_TOOLS) {
+    throw new Error("Child capability probe returned an unsupported snapshot.");
+  }
+  const tools = report.tools.map((candidate, index): ToolCapability => {
+    if (!candidate || typeof candidate !== "object") {
+      throw new Error(`Child capability probe tool ${index + 1} is invalid.`);
+    }
+    const tool = candidate as { name?: unknown; provider?: unknown };
+    if (typeof tool.name !== "string" || typeof tool.provider !== "string") {
+      throw new Error(`Child capability probe tool ${index + 1} is invalid.`);
+    }
+    assertBounded(tool.name, `Child capability probe tool ${index + 1} name`, MAX_TOOL_NAME_LENGTH);
+    assertBounded(tool.provider, `Child capability probe tool "${tool.name}" provider`, MAX_PROVIDER_LENGTH);
+    return { name: tool.name, provider: tool.provider };
+  });
+  if (new Set(tools.map((tool) => tool.name)).size !== tools.length) {
+    throw new Error("Child capability probe returned duplicate tool names.");
+  }
+  return {
+    tools,
+    extensionPaths: unique(
+      tools
+        .map((tool) => tool.provider)
+        .filter((provider) => provider !== BUILTIN_TOOL_PROVIDER),
+    ),
+  };
+}
+
+function describeCapability(capability: ToolCapability): string {
+  return `${capability.name} (${diagnosticValue(capability.provider)})`;
+}
+
+export function assertCapabilityMatch(
+  promised: CapabilitySnapshot,
+  actual: CapabilitySnapshot,
+): void {
+  const actualByName = new Map(actual.tools.map((tool) => [tool.name, tool]));
+  const problems: string[] = [];
+  let problemCount = 0;
+  const addProblem = (problem: string) => {
+    problemCount += 1;
+    if (problems.length < MAX_DIAGNOSTIC_PROBLEMS) problems.push(problem);
+  };
+
+  for (const expected of promised.tools) {
+    const received = actualByName.get(expected.name);
+    if (!received) {
+      addProblem(`${expected.name} (expected ${diagnosticValue(expected.provider)}, missing)`);
+      continue;
+    }
+    if (received.provider !== expected.provider) {
+      addProblem(
+        `${expected.name} (expected ${diagnosticValue(expected.provider)}, got ${diagnosticValue(received.provider)})`,
+      );
+    }
+    actualByName.delete(expected.name);
+  }
+  for (const unexpected of actualByName.values()) {
+    addProblem(`unexpected ${describeCapability(unexpected)}`);
+  }
+
+  if (problemCount > 0) {
+    const remaining = problemCount - problems.length;
+    const suffix = remaining > 0 ? `; and ${remaining} more` : "";
+    throw new Error(`Child capability preflight mismatch: ${problems.join("; ")}${suffix}.`);
+  }
+}

--- a/extensions/subagents/capabilities.ts
+++ b/extensions/subagents/capabilities.ts
@@ -45,12 +45,12 @@ function diagnosticValue(value: string): string {
 function loadableProvider(tool: ReturnType<ExtensionAPI["getAllTools"]>[number]): string {
   if (tool.sourceInfo.source === "builtin") return BUILTIN_TOOL_PROVIDER;
   const provider = tool.sourceInfo.path;
+  assertBounded(provider, `Provider for active tool "${tool.name}"`, MAX_PROVIDER_LENGTH);
   if (tool.sourceInfo.source === "sdk" || provider.startsWith("<")) {
     throw new Error(
-      `Active tool "${tool.name}" cannot be inherited because provider "${provider}" is not a loadable extension path.`,
+      `Active tool "${tool.name}" cannot be inherited because provider "${diagnosticValue(provider)}" is not a loadable extension path.`,
     );
   }
-  assertBounded(provider, `Provider for active tool "${tool.name}"`, MAX_PROVIDER_LENGTH);
   return provider;
 }
 

--- a/extensions/subagents/capability-probe.test.ts
+++ b/extensions/subagents/capability-probe.test.ts
@@ -1,0 +1,60 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { BUILTIN_TOOL_PROVIDER, CAPABILITY_PROBE_STATUS_KEY } from "./capabilities.ts";
+import capabilityProbe from "./capability-probe.ts";
+
+describe("child capability probe", () => {
+  it("reports the child's exact active tool providers through the RPC UI protocol", () => {
+    let sessionStart: ((event: unknown, ctx: ExtensionContext) => void) | undefined;
+    const pi = {
+      on: (event: string, handler: (event: unknown, ctx: ExtensionContext) => void) => {
+        if (event === "session_start") sessionStart = handler;
+      },
+      getActiveTools: () => ["read", "browser_fetch"],
+      getAllTools: () => [
+        {
+          name: "read",
+          sourceInfo: { source: "builtin", path: "<builtin:read>" },
+        },
+        {
+          name: "browser_fetch",
+          sourceInfo: { source: "cli", path: "/extensions/browser-fetch/index.ts" },
+        },
+      ],
+    } as unknown as ExtensionAPI;
+    const statuses: Array<{ key: string; text?: string }> = [];
+    const ctx = {
+      mode: "rpc",
+      ui: { setStatus: (key: string, text?: string) => statuses.push({ key, text }) },
+    } as unknown as ExtensionContext;
+
+    capabilityProbe(pi);
+    expect(sessionStart).toBeDefined();
+    sessionStart?.({}, ctx);
+
+    expect(statuses).toHaveLength(1);
+    expect(statuses[0].key).toBe(CAPABILITY_PROBE_STATUS_KEY);
+    expect(JSON.parse(statuses[0].text ?? "")).toEqual({
+      version: 1,
+      tools: [
+        { name: "read", provider: BUILTIN_TOOL_PROVIDER },
+        { name: "browser_fetch", provider: "/extensions/browser-fetch/index.ts" },
+      ],
+    });
+  });
+
+  it("is inert outside RPC mode", () => {
+    let sessionStart: ((event: unknown, ctx: ExtensionContext) => void) | undefined;
+    const pi = {
+      on: (_event: string, handler: (event: unknown, ctx: ExtensionContext) => void) => {
+        sessionStart = handler;
+      },
+    } as unknown as ExtensionAPI;
+    const setStatus = () => {
+      throw new Error("unexpected status");
+    };
+
+    capabilityProbe(pi);
+    sessionStart?.({}, { mode: "print", ui: { setStatus } } as unknown as ExtensionContext);
+  });
+});

--- a/extensions/subagents/capability-probe.ts
+++ b/extensions/subagents/capability-probe.ts
@@ -1,0 +1,27 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+  BUILTIN_TOOL_PROVIDER,
+  CAPABILITY_PROBE_STATUS_KEY,
+  type ToolCapability,
+} from "./capabilities.ts";
+
+export default function capabilityProbe(pi: ExtensionAPI): void {
+  pi.on("session_start", (_event, ctx) => {
+    if (ctx.mode !== "rpc") return;
+    const configured = new Map(pi.getAllTools().map((tool) => [tool.name, tool]));
+    const tools = pi.getActiveTools().map((name): ToolCapability => {
+      const tool = configured.get(name);
+      if (!tool) return { name, provider: "<missing-provider>" };
+      return {
+        name,
+        provider: tool.sourceInfo.source === "builtin"
+          ? BUILTIN_TOOL_PROVIDER
+          : tool.sourceInfo.path,
+      };
+    });
+    ctx.ui.setStatus(
+      CAPABILITY_PROBE_STATUS_KEY,
+      JSON.stringify({ version: 1, tools }),
+    );
+  });
+}

--- a/extensions/subagents/controller.test.ts
+++ b/extensions/subagents/controller.test.ts
@@ -5,6 +5,16 @@ import {
   type RpcChild,
   type RpcEvent,
 } from "./controller.ts";
+import {
+  BUILTIN_TOOL_PROVIDER,
+  cloneCapabilities,
+  type CapabilitySnapshot,
+} from "./capabilities.ts";
+
+const DEFAULT_CAPABILITIES: CapabilitySnapshot = {
+  tools: [{ name: "read", provider: BUILTIN_TOOL_PROVIDER }],
+  extensionPaths: [],
+};
 
 class FakeChild implements RpcChild {
   readonly requests: Array<Record<string, unknown>> = [];
@@ -37,6 +47,10 @@ class FakeChild implements RpcChild {
     if (command.type === "prompt") await this.promptGate;
     if (command.type === "get_last_assistant_text") return { text: this.finalText };
     return undefined;
+  }
+
+  async getCapabilities(): Promise<CapabilitySnapshot> {
+    return cloneCapabilities(this.spec.capabilities);
   }
 
   onEvent(listener: (event: RpcEvent) => void): () => void {
@@ -89,7 +103,7 @@ async function settle(child: FakeChild): Promise<void> {
 describe("SubagentController", () => {
   it("returns after prompt acceptance and before completion", async () => {
     const { controller, children, pongs } = setup({ delayedPrompt: true });
-    const starting = controller.start({ prompt: "inspect", cwd: "/repo", model: "p/m", thinking: "high" });
+    const starting = controller.start({ prompt: "inspect", cwd: "/repo", model: "p/m", thinking: "high", capabilities: DEFAULT_CAPABILITIES });
     await vi.waitFor(() => expect(children).toHaveLength(1));
     expect(controller.list()[0]?.state).toBe("handshaking");
 
@@ -107,6 +121,7 @@ describe("SubagentController", () => {
       cwd: "/repo",
       model: "p/m",
       thinking: "medium",
+      capabilities: DEFAULT_CAPABILITIES,
       name: "worker",
     }).then((pong) => {
       completed = true;
@@ -132,9 +147,9 @@ describe("SubagentController", () => {
     const { controller, children } = setup();
     let firstCompleted = false;
     let secondCompleted = false;
-    const first = controller.run({ prompt: "one", cwd: "/repo", model: "p/m", thinking: "medium" })
+    const first = controller.run({ prompt: "one", cwd: "/repo", model: "p/m", thinking: "medium", capabilities: DEFAULT_CAPABILITIES })
       .then((pong) => { firstCompleted = true; return pong; });
-    const second = controller.run({ prompt: "two", cwd: "/repo", model: "p/m", thinking: "medium" })
+    const second = controller.run({ prompt: "two", cwd: "/repo", model: "p/m", thinking: "medium", capabilities: DEFAULT_CAPABILITIES })
       .then((pong) => { secondCompleted = true; return pong; });
 
     await vi.waitFor(() => expect(children).toHaveLength(2));
@@ -154,7 +169,7 @@ describe("SubagentController", () => {
     const { controller, children, pongs } = setup();
     const cancellation = new AbortController();
     const running = controller.run(
-      { prompt: "work", cwd: "/repo", model: "p/m", thinking: "medium" },
+      { prompt: "work", cwd: "/repo", model: "p/m", thinking: "medium", capabilities: DEFAULT_CAPABILITIES },
       cancellation.signal,
     );
 
@@ -169,14 +184,14 @@ describe("SubagentController", () => {
 
   it("runs twelve children and rejects a thirteenth without queuing", async () => {
     const { controller, children } = setup();
-    await Promise.all(Array.from({ length: 12 }, (_, index) => controller.start({ prompt: `${index}`, cwd: "/repo", model: "p/m", thinking: "low" })));
-    await expect(controller.start({ prompt: "thirteenth", cwd: "/repo", model: "p/m", thinking: "low" })).rejects.toThrow("12");
+    await Promise.all(Array.from({ length: 12 }, (_, index) => controller.start({ prompt: `${index}`, cwd: "/repo", model: "p/m", thinking: "low", capabilities: DEFAULT_CAPABILITIES })));
+    await expect(controller.start({ prompt: "thirteenth", cwd: "/repo", model: "p/m", thinking: "low", capabilities: DEFAULT_CAPABILITIES })).rejects.toThrow("12");
     expect(children).toHaveLength(12);
   });
 
   it("times out pre-acceptance without a pong", async () => {
     const { controller, children, pongs } = setup({ delayedPrompt: true, handshakeMs: 5 });
-    await expect(controller.start({ prompt: "slow", cwd: "/repo", model: "p/m", thinking: "low" })).rejects.toThrow("accept");
+    await expect(controller.start({ prompt: "slow", cwd: "/repo", model: "p/m", thinking: "low", capabilities: DEFAULT_CAPABILITIES })).rejects.toThrow("accept");
     expect(children[0].closed).toBe(true);
     expect(controller.list()).toEqual([]);
     expect(pongs).toEqual([]);
@@ -184,7 +199,7 @@ describe("SubagentController", () => {
 
   it.each(["completed", "interrupted"] as const)("emits exactly one %s pong after process close", async (outcome) => {
     const { controller, children, pongs } = setup();
-    await controller.start({ prompt: "work", cwd: "/repo", model: "p/m", thinking: "medium", name: "worker" });
+    await controller.start({ prompt: "work", cwd: "/repo", model: "p/m", thinking: "medium", capabilities: DEFAULT_CAPABILITIES, name: "worker" });
     children[0].finalText = "done";
     if (outcome === "interrupted") await controller.interrupt(1);
     await settle(children[0]);
@@ -197,7 +212,7 @@ describe("SubagentController", () => {
 
   it("emits one failed pong when an accepted child crashes", async () => {
     const { controller, children, pongs } = setup();
-    await controller.start({ prompt: "work", cwd: "/repo", model: "p/m", thinking: "medium" });
+    await controller.start({ prompt: "work", cwd: "/repo", model: "p/m", thinking: "medium", capabilities: DEFAULT_CAPABILITIES });
     children[0].crash("boom");
     await vi.waitFor(() => expect(pongs).toHaveLength(1));
     expect(pongs[0]).toMatchObject({ outcome: "failed", error: "boom" });
@@ -205,7 +220,7 @@ describe("SubagentController", () => {
 
   it("reports a settled assistant error as failed", async () => {
     const { controller, children, pongs } = setup();
-    await controller.start({ prompt: "work", cwd: "/repo", model: "p/m", thinking: "medium" });
+    await controller.start({ prompt: "work", cwd: "/repo", model: "p/m", thinking: "medium", capabilities: DEFAULT_CAPABILITIES });
     children[0].emit({ type: "message_end", message: { role: "assistant", stopReason: "error", errorMessage: "provider failed" } });
     await settle(children[0]);
     expect(pongs[0]).toMatchObject({ outcome: "failed", error: "provider failed" });
@@ -213,17 +228,17 @@ describe("SubagentController", () => {
 
   it("continues the same session with the routing values supplied for the new turn", async () => {
     const { controller, children } = setup();
-    await controller.start({ prompt: "one", cwd: "/repo", model: "p/old", thinking: "low", tools: ["read"] });
+    await controller.start({ prompt: "one", cwd: "/repo", model: "p/old", thinking: "low", capabilities: DEFAULT_CAPABILITIES });
     await settle(children[0]);
 
-    await controller.continue({ id: 1, prompt: "two", model: "p/current", thinking: "high" });
-    expect(children[1].spec).toMatchObject({ session: "/sessions/1.jsonl", cwd: "/repo", model: "p/current", thinking: "high", tools: ["read"] });
-    await expect(controller.continue({ id: 1, prompt: "three", model: "p/current", thinking: "high" })).rejects.toThrow("active");
+    await controller.continue({ id: 1, prompt: "two", model: "p/current", thinking: "high", capabilities: DEFAULT_CAPABILITIES });
+    expect(children[1].spec).toMatchObject({ session: "/sessions/1.jsonl", cwd: "/repo", model: "p/current", thinking: "high", capabilities: DEFAULT_CAPABILITIES });
+    await expect(controller.continue({ id: 1, prompt: "three", model: "p/current", thinking: "high", capabilities: DEFAULT_CAPABILITIES })).rejects.toThrow("active");
   });
 
   it("waits for a direct continuation without emitting another pong", async () => {
     const { controller, children, pongs } = setup();
-    await controller.start({ prompt: "one", cwd: "/repo", model: "p/m", thinking: "low" });
+    await controller.start({ prompt: "one", cwd: "/repo", model: "p/m", thinking: "low", capabilities: DEFAULT_CAPABILITIES });
     await settle(children[0]);
     expect(pongs).toHaveLength(1);
 
@@ -232,6 +247,7 @@ describe("SubagentController", () => {
       prompt: "two",
       model: "p/m",
       thinking: "high",
+      capabilities: DEFAULT_CAPABILITIES,
     });
     await vi.waitFor(() => expect(children).toHaveLength(2));
     children[1].finalText = "continued";
@@ -247,7 +263,7 @@ describe("SubagentController", () => {
 
   it("allows steering only while active", async () => {
     const { controller, children } = setup();
-    await controller.start({ prompt: "one", cwd: "/repo", model: "p/m", thinking: "low" });
+    await controller.start({ prompt: "one", cwd: "/repo", model: "p/m", thinking: "low", capabilities: DEFAULT_CAPABILITIES });
     await controller.steer(1, "change course");
     expect(children[0].requests).toContainEqual({ type: "steer", message: "change course" });
     await settle(children[0]);
@@ -256,7 +272,7 @@ describe("SubagentController", () => {
 
   it("tracks tool activity and visible text without thinking", async () => {
     const { controller, children } = setup();
-    await controller.start({ prompt: "one", cwd: "/repo", model: "p/m", thinking: "low" });
+    await controller.start({ prompt: "one", cwd: "/repo", model: "p/m", thinking: "low", capabilities: DEFAULT_CAPABILITIES });
     children[0].emit({ type: "message_update", assistantMessageEvent: { type: "thinking_delta", delta: "secret" } });
     children[0].emit({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "visible" } });
     children[0].emit({ type: "tool_execution_start", toolName: "read" });
@@ -266,8 +282,8 @@ describe("SubagentController", () => {
   it("suppresses pongs and clears state on shutdown", async () => {
     const { controller, children, pongs } = setup();
     await Promise.all([
-      controller.start({ prompt: "one", cwd: "/repo", model: "p/m", thinking: "low" }),
-      controller.start({ prompt: "two", cwd: "/repo", model: "p/m", thinking: "low" }),
+      controller.start({ prompt: "one", cwd: "/repo", model: "p/m", thinking: "low", capabilities: DEFAULT_CAPABILITIES }),
+      controller.start({ prompt: "two", cwd: "/repo", model: "p/m", thinking: "low", capabilities: DEFAULT_CAPABILITIES }),
     ]);
     await controller.shutdown();
     expect(children.every((child) => child.closed)).toBe(true);

--- a/extensions/subagents/controller.test.ts
+++ b/extensions/subagents/controller.test.ts
@@ -26,10 +26,17 @@ class FakeChild implements RpcChild {
   private exitListeners: Array<(error?: Error) => void> = [];
   private promptGate?: Promise<void>;
   private releasePrompt?: () => void;
+  private readonly reportedCapabilities?: CapabilitySnapshot;
 
-  constructor(spec: LaunchSpec, sessionFile: string, delayedPrompt = false) {
+  constructor(
+    spec: LaunchSpec,
+    sessionFile: string,
+    delayedPrompt = false,
+    reportedCapabilities?: CapabilitySnapshot,
+  ) {
     this.spec = spec;
     this.sessionFile = sessionFile;
+    this.reportedCapabilities = reportedCapabilities;
     if (delayedPrompt) {
       this.promptGate = new Promise((resolve) => {
         this.releasePrompt = resolve;
@@ -50,7 +57,7 @@ class FakeChild implements RpcChild {
   }
 
   async getCapabilities(): Promise<CapabilitySnapshot> {
-    return cloneCapabilities(this.spec.capabilities);
+    return cloneCapabilities(this.reportedCapabilities ?? this.spec.capabilities);
   }
 
   onEvent(listener: (event: RpcEvent) => void): () => void {
@@ -80,13 +87,22 @@ class FakeChild implements RpcChild {
   }
 }
 
-function setup(options: { delayedPrompt?: boolean; handshakeMs?: number } = {}) {
+function setup(options: {
+  delayedPrompt?: boolean;
+  handshakeMs?: number;
+  reportedCapabilities?: CapabilitySnapshot;
+} = {}) {
   const children: FakeChild[] = [];
   const pongs: unknown[] = [];
   const controller = new SubagentController({
     handshakeMs: options.handshakeMs ?? 100,
     createChild: async (spec) => {
-      const child = new FakeChild(spec, `/sessions/${children.length + 1}.jsonl`, options.delayedPrompt);
+      const child = new FakeChild(
+        spec,
+        `/sessions/${children.length + 1}.jsonl`,
+        options.delayedPrompt,
+        options.reportedCapabilities,
+      );
       children.push(child);
       return child;
     },
@@ -195,6 +211,32 @@ describe("SubagentController", () => {
     expect(children[0].closed).toBe(true);
     expect(controller.list()).toEqual([]);
     expect(pongs).toEqual([]);
+  });
+
+  it("preserves the original capability preflight failure as the dispatch error cause", async () => {
+    const { controller } = setup({
+      reportedCapabilities: { tools: [], extensionPaths: [] },
+    });
+    let captured: unknown;
+
+    try {
+      await controller.start({
+        prompt: "inspect",
+        cwd: "/repo",
+        model: "p/m",
+        thinking: "low",
+        capabilities: DEFAULT_CAPABILITIES,
+      });
+    } catch (error) {
+      captured = error;
+    }
+
+    expect(captured).toBeInstanceOf(Error);
+    expect((captured as Error).message).toContain("Subagent dispatch was not accepted");
+    expect((captured as Error).cause).toBeInstanceOf(Error);
+    expect(((captured as Error).cause as Error).message).toContain(
+      "Child capability preflight mismatch",
+    );
   });
 
   it.each(["completed", "interrupted"] as const)("emits exactly one %s pong after process close", async (outcome) => {

--- a/extensions/subagents/controller.ts
+++ b/extensions/subagents/controller.ts
@@ -326,7 +326,7 @@ export class SubagentController {
       } catch {
         // Preserve the original handshake error.
       }
-      throw new Error(`Subagent dispatch was not accepted: ${errorMessage(error)}`);
+      throw new Error(`Subagent dispatch was not accepted: ${errorMessage(error)}`, { cause: error });
     }
   }
 

--- a/extensions/subagents/controller.ts
+++ b/extensions/subagents/controller.ts
@@ -1,3 +1,9 @@
+import {
+  assertCapabilityMatch,
+  cloneCapabilities,
+  type CapabilitySnapshot,
+} from "./capabilities.ts";
+
 export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 export type TerminalOutcome = "completed" | "failed" | "interrupted";
 export type SubagentState = "handshaking" | "running" | "steering" | "interrupting" | "finalizing" | TerminalOutcome;
@@ -6,7 +12,7 @@ export interface LaunchSpec {
   cwd: string;
   model: string;
   thinking: ThinkingLevel;
-  tools?: string[];
+  capabilities: CapabilitySnapshot;
   name?: string;
   session?: string;
 }
@@ -20,6 +26,7 @@ export interface RpcEvent {
 
 export interface RpcChild {
   request(command: Record<string, unknown>): Promise<unknown>;
+  getCapabilities(): Promise<CapabilitySnapshot>;
   onEvent(listener: (event: RpcEvent) => void): () => void;
   onExit(listener: (error?: Error) => void): () => void;
   close(): Promise<void>;
@@ -34,7 +41,7 @@ export interface ContinueInput {
   prompt: string;
   model: string;
   thinking: ThinkingLevel;
-  tools?: string[];
+  capabilities: CapabilitySnapshot;
 }
 
 export interface SubagentView {
@@ -63,6 +70,7 @@ export interface Pong {
 }
 
 interface RecordState extends SubagentView {
+  capabilities: CapabilitySnapshot;
   child?: RpcChild;
   accepted: boolean;
   finalizing: boolean;
@@ -112,9 +120,9 @@ export class SubagentController {
   }
 
   list(): SubagentView[] {
-    return [...this.records.values()].map(({ child: _child, accepted: _accepted, finalizing: _finalizing, ponged: _ponged, interruptRequested: _interruptRequested, pendingSettled: _pendingSettled, pendingExitError: _pendingExitError, terminalError: _terminalError, directResolve: _directResolve, ...view }) => ({
+    return [...this.records.values()].map(({ capabilities, child: _child, accepted: _accepted, finalizing: _finalizing, ponged: _ponged, interruptRequested: _interruptRequested, pendingSettled: _pendingSettled, pendingExitError: _pendingExitError, terminalError: _terminalError, directResolve: _directResolve, ...view }) => ({
       ...view,
-      tools: view.tools ? [...view.tools] : undefined,
+      tools: capabilities.tools.map((tool) => tool.name),
     }));
   }
 
@@ -194,12 +202,12 @@ export class SubagentController {
       error: record.error,
       model: record.model,
       thinking: record.thinking,
-      tools: record.tools ? [...record.tools] : undefined,
+      capabilities: cloneCapabilities(record.capabilities),
       directResolve: record.directResolve,
     };
     record.model = input.model;
     record.thinking = input.thinking;
-    if (input.tools !== undefined) record.tools = [...input.tools];
+    record.capabilities = cloneCapabilities(input.capabilities);
     record.state = "handshaking";
     record.active = true;
     record.startedAt = this.options.now();
@@ -224,7 +232,7 @@ export class SubagentController {
       record.error = previous.error;
       record.model = previous.model;
       record.thinking = previous.thinking;
-      record.tools = previous.tools;
+      record.capabilities = previous.capabilities;
       record.directResolve = previous.directResolve;
       record.active = false;
       record.startedAt = undefined;
@@ -285,7 +293,7 @@ export class SubagentController {
       cwd: record.cwd,
       model: record.model,
       thinking: record.thinking,
-      tools: record.tools ? [...record.tools] : undefined,
+      capabilities: cloneCapabilities(record.capabilities),
       name: record.name,
       session: record.sessionRef,
     };
@@ -297,6 +305,7 @@ export class SubagentController {
         record.child = child;
         child.onEvent((event) => this.handleEvent(record, event));
         child.onExit((error) => this.handleExit(record, error));
+        assertCapabilityMatch(spec.capabilities, await child.getCapabilities());
         const state = stateData(await child.request({ type: "get_state" }));
         if (!state.sessionFile) throw new Error("Child did not provide a native session reference.");
         record.sessionRef = state.sessionFile;
@@ -317,7 +326,7 @@ export class SubagentController {
       } catch {
         // Preserve the original handshake error.
       }
-      throw new Error(`Subagent prompt was not accepted: ${errorMessage(error)}`);
+      throw new Error(`Subagent dispatch was not accepted: ${errorMessage(error)}`);
     }
   }
 
@@ -419,7 +428,7 @@ export class SubagentController {
       cwd: input.cwd,
       model: input.model,
       thinking: input.thinking,
-      tools: input.tools ? [...input.tools] : undefined,
+      capabilities: cloneCapabilities(input.capabilities),
       accepted: false,
       finalizing: false,
       ponged: false,

--- a/extensions/subagents/index.ts
+++ b/extensions/subagents/index.ts
@@ -1,6 +1,5 @@
 import { resolve } from "node:path";
 import {
-  getAgentDir,
   keyHint,
   type ExtensionAPI,
   type ExtensionContext,
@@ -17,19 +16,19 @@ import {
   type ThinkingLevel,
 } from "./controller.ts";
 import { buildChildInvocation, RpcSubprocess } from "./rpc-child.ts";
+import { captureCapabilities } from "./capabilities.ts";
 import { publishAsyncActivity } from "./async-activity.ts";
 
 const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
 const THINKING_LEVEL_SET = new Set<string>(THINKING_LEVELS);
-const NATIVE_TOOLS = new Set(["read", "bash", "edit", "write", "grep", "find", "ls"]);
 const PONG_TEXT_LIMIT = 8_000;
 
 const ReasoningSchema = StringEnum(THINKING_LEVELS, {
   description: "Reasoning override for this dispatch; omit to inherit the orchestrator's current level",
 });
-const ToolsSchema = Type.Array(Type.String(), {
-  minItems: 1,
-  description: "Allowlist of native Pi tools: read, bash, edit, write, grep, find, ls",
+const ToolsSchema = Type.Array(Type.String({ minLength: 1, maxLength: 256 }), {
+  maxItems: 256,
+  description: "Optional restriction that keeps only these tools from the parent's active capability snapshot; omission inherits every active tool",
 });
 
 const StartSchema = Type.Object({
@@ -65,13 +64,6 @@ const ListSchema = Type.Object({});
 
 type StartParams = Static<typeof StartSchema>;
 type ContinueParams = Static<typeof ContinueSchema>;
-
-function validateTools(tools?: string[]): string[] | undefined {
-  if (!tools) return undefined;
-  const invalid = tools.filter((tool) => !NATIVE_TOOLS.has(tool));
-  if (invalid.length) throw new Error(`Only native Pi tools are allowed. Invalid: ${invalid.join(", ")}.`);
-  return [...new Set(tools)];
-}
 
 function activeModel(ctx: ExtensionContext): string {
   if (!ctx.model) throw new Error("The orchestrator has no active model to inherit.");
@@ -214,7 +206,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
   };
 
   controller = new SubagentController({
-    createChild: async (spec) => new RpcSubprocess(buildChildInvocation(spec, resolve(getAgentDir(), "skills"))),
+    createChild: async (spec) => new RpcSubprocess(buildChildInvocation(spec)),
     onPong: sendPong,
     onChange: refreshUi,
   });
@@ -225,7 +217,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
     model: selectedModel(params.model, ctx),
     thinking: selectedThinking(params.reasoning, pi.getThinkingLevel() as ThinkingLevel),
     cwd: resolve(ctx.cwd, params.cwd ?? "."),
-    tools: validateTools(params.tools),
+    capabilities: captureCapabilities(pi, params.tools),
   });
 
   const start = (params: StartParams, ctx: ExtensionContext): Promise<SubagentView> => {
@@ -237,7 +229,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
     prompt: params.prompt,
     model: selectedModel(params.model, ctx),
     thinking: selectedThinking(params.reasoning, pi.getThinkingLevel() as ThinkingLevel),
-    tools: validateTools(params.tools),
+    capabilities: captureCapabilities(pi, params.tools),
   });
 
   const continueSubagent = (params: ContinueParams, ctx: ExtensionContext): Promise<SubagentView> => {
@@ -247,7 +239,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
   pi.registerTool({
     name: "subagent_start",
     label: "Start Subagent",
-    description: 'Start a clean persistent Pi conversation. In print mode, the tool waits for terminal completion and returns the bounded final result directly. In other modes, it returns after RPC prompt acceptance and completion arrives later as one pong. Optional model or reasoning overrides apply only for an explicit user request; model overrides require "<provider>/<model>".',
+    description: 'Start a clean persistent Pi conversation with the parent\'s active tools and required extension providers. Omit tools to inherit the complete active snapshot; an explicit list can only narrow it. Normal skills and repository instructions are discovered for the child cwd. In print mode, the tool waits for terminal completion and returns the bounded final result directly. In other modes, it returns after RPC prompt acceptance and completion arrives later as one pong. Optional model or reasoning overrides apply only for an explicit user request; model overrides require "<provider>/<model>".',
     promptSnippet: "Start an independent Pi conversation with a complete prompt",
     promptGuidelines: [
       "Set each subagent_start model or reasoning override only when the user explicitly requests that value for this dispatch; explicit model overrides must use the qualified <provider>/<model> form. Omit every unrequested override so it inherits the orchestrator's active value.",
@@ -281,7 +273,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
   pi.registerTool({
     name: "subagent_continue",
     label: "Continue Subagent",
-    description: 'Start another turn in a settled known subagent conversation. In print mode, the tool waits for terminal completion and returns the bounded final result directly. In other modes, it returns after prompt acceptance and completion arrives later as one pong. Optional model or reasoning overrides apply only for an explicit user request; model overrides require "<provider>/<model>".',
+    description: 'Start another turn in a settled known subagent conversation with a fresh snapshot of the parent\'s active tools and required extension providers. Omit tools to inherit the complete active snapshot; an explicit list can only narrow it. In print mode, the tool waits for terminal completion and returns the bounded final result directly. In other modes, it returns after prompt acceptance and completion arrives later as one pong. Optional model or reasoning overrides apply only for an explicit user request; model overrides require "<provider>/<model>".',
     promptGuidelines: [
       "Set each subagent_continue model or reasoning override only when the user explicitly requests that value for this dispatch; explicit model overrides must use the qualified <provider>/<model> form. Omit every unrequested override so it inherits the orchestrator's active value.",
       "Only after deciding to call subagent_continue, inspect PI_PROVIDER, PI_MODEL, and PI_REASONING_LEVEL to identify the orchestrator's active route immediately before dispatch. Do not inspect routing on ordinary turns or merely because this tool is available. Unless the user explicitly requests routing, omit model and reasoning overrides so the dispatch inherits that active route rather than forcing a global or preferred default.",

--- a/extensions/subagents/inheritance.test.ts
+++ b/extensions/subagents/inheritance.test.ts
@@ -3,8 +3,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const rpc = vi.hoisted(() => ({
   invocations: [] as Array<{ args: string[] }>,
+  capabilityReports: [] as Array<{
+    tools: Array<{ name: string; provider: string }>;
+    extensionPaths: string[];
+  }>,
   children: [] as Array<{
     closed: boolean;
+    requests: Array<Record<string, unknown>>;
     emit(event: { type: string }): void;
   }>,
 }));
@@ -15,8 +20,13 @@ vi.mock("./rpc-child.ts", async (importOriginal) => {
     ...actual,
     RpcSubprocess: class {
       closed = false;
+      requests: Array<Record<string, unknown>> = [];
       private listeners: Array<(event: { type: string }) => void> = [];
       private readonly sessionFile: string;
+      private readonly capabilities: {
+        tools: Array<{ name: string; provider: string }>;
+        extensionPaths: string[];
+      };
 
       constructor(invocation: { args: string[] }) {
         rpc.invocations.push({ args: invocation.args });
@@ -24,13 +34,24 @@ vi.mock("./rpc-child.ts", async (importOriginal) => {
         this.sessionFile = sessionIndex >= 0
           ? invocation.args[sessionIndex + 1]
           : `/sessions/${rpc.children.length + 1}.jsonl`;
+        const toolsIndex = invocation.args.indexOf("--tools");
+        const names = toolsIndex >= 0 ? invocation.args[toolsIndex + 1].split(",") : [];
+        this.capabilities = rpc.capabilityReports.shift() ?? {
+          tools: names.map((name) => ({ name, provider: "builtin" })),
+          extensionPaths: [],
+        };
         rpc.children.push(this);
       }
 
       async request(command: Record<string, unknown>): Promise<unknown> {
+        this.requests.push(command);
         if (command.type === "get_state") return { sessionFile: this.sessionFile };
         if (command.type === "get_last_assistant_text") return { text: "done" };
         return undefined;
+      }
+
+      async getCapabilities() {
+        return this.capabilities;
       }
 
       onEvent(listener: (event: { type: string }) => void): () => void {
@@ -66,12 +87,26 @@ function setup() {
   const messages: unknown[] = [];
   const activityEvents: Array<{ channel: string; data: unknown }> = [];
   let thinking = "low";
+  let activeTools = ["read", "bash", "edit", "write"];
+  let configuredTools = ["read", "bash", "edit", "write", "grep", "find", "ls"].map((name) => ({
+    name,
+    description: `${name} description`,
+    parameters: {},
+    sourceInfo: {
+      source: "builtin",
+      path: `<builtin:${name}>`,
+      scope: "temporary",
+      origin: "top-level",
+    },
+  }));
   const pi = {
     registerTool: (tool: { name: string }) => tools.set(tool.name, tool),
     registerCommand: (name: string, command: unknown) => commands.set(name, command),
     registerMessageRenderer: () => undefined,
     on: () => undefined,
     getThinkingLevel: () => thinking,
+    getActiveTools: () => [...activeTools],
+    getAllTools: () => configuredTools.map((tool) => ({ ...tool })),
     sendMessage: (message: unknown) => messages.push(message),
     events: {
       emit: (channel: string, data: unknown) => activityEvents.push({ channel, data }),
@@ -93,6 +128,13 @@ function setup() {
     notifications,
     activityEvents,
     setThinking: (level: string) => { thinking = level; },
+    setCapabilities: (
+      active: string[],
+      configured: typeof configuredTools,
+    ) => {
+      activeTools = [...active];
+      configuredTools = configured.map((tool) => ({ ...tool }));
+    },
   };
 }
 
@@ -104,6 +146,7 @@ async function settle(index: number): Promise<void> {
 describe("subagent routing inheritance", () => {
   beforeEach(() => {
     rpc.invocations.length = 0;
+    rpc.capabilityReports.length = 0;
     rpc.children.length = 0;
   });
 
@@ -128,6 +171,168 @@ describe("subagent routing inheritance", () => {
       channel: "ompi:async-activity",
       data: { source: "subagents", active: 0 },
     });
+  });
+
+  it("inherits each then-active extension tool and provider on start and continuation", async () => {
+    const { tools, ctx, setCapabilities } = setup();
+    const builtins = ["read", "bash"].map((name) => ({
+      name,
+      description: `${name} description`,
+      parameters: {},
+      sourceInfo: {
+        source: "builtin",
+        path: `<builtin:${name}>`,
+        scope: "temporary",
+        origin: "top-level",
+      },
+    }));
+    const extensionTool = {
+      name: "browser_fetch",
+      description: "Fetch a rendered page",
+      parameters: {},
+      sourceInfo: {
+        source: "cli",
+        path: "/extensions/browser-fetch/index.ts",
+        scope: "temporary",
+        origin: "top-level",
+      },
+    };
+    setCapabilities(["read", "browser_fetch"], [...builtins, extensionTool]);
+    rpc.capabilityReports.push({
+      tools: [
+        { name: "read", provider: "builtin" },
+        { name: "browser_fetch", provider: "/extensions/browser-fetch/index.ts" },
+      ],
+      extensionPaths: ["/extensions/browser-fetch/index.ts"],
+    });
+
+    await tools.get("subagent_start").execute(
+      "start",
+      { prompt: "one", name: "reviewer" },
+      undefined,
+      undefined,
+      ctx,
+    );
+    expect(valueAfter(rpc.invocations[0].args, "--tools")).toBe("read,browser_fetch");
+    expect(valueAfter(rpc.invocations[0].args, "--extension")).toBe(
+      "/extensions/browser-fetch/index.ts",
+    );
+    await settle(0);
+
+    setCapabilities(["bash", "browser_fetch"], [...builtins, extensionTool]);
+    rpc.capabilityReports.push({
+      tools: [
+        { name: "bash", provider: "builtin" },
+        { name: "browser_fetch", provider: "/extensions/browser-fetch/index.ts" },
+      ],
+      extensionPaths: ["/extensions/browser-fetch/index.ts"],
+    });
+    await tools.get("subagent_continue").execute(
+      "continue",
+      { id: 1, prompt: "two" },
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    expect(valueAfter(rpc.invocations[1].args, "--tools")).toBe("bash,browser_fetch");
+    expect(valueAfter(rpc.invocations[1].args, "--extension")).toBe(
+      "/extensions/browser-fetch/index.ts",
+    );
+  });
+
+  it("treats tools as monotonic restrictions and gives names no hidden capability effect", async () => {
+    const { tools, ctx, setCapabilities } = setup();
+    const configured = ["read", "write"].map((name) => ({
+      name,
+      description: `${name} description`,
+      parameters: {},
+      sourceInfo: {
+        source: "builtin",
+        path: `<builtin:${name}>`,
+        scope: "temporary",
+        origin: "top-level",
+      },
+    }));
+    setCapabilities(["read"], configured);
+
+    await tools.get("subagent_start").execute(
+      "named",
+      { prompt: "one", name: "writer" },
+      undefined,
+      undefined,
+      ctx,
+    );
+    expect(valueAfter(rpc.invocations[0].args, "--tools")).toBe("read");
+
+    await expect(tools.get("subagent_start").execute(
+      "escalate",
+      { prompt: "two", tools: ["write"] },
+      undefined,
+      undefined,
+      ctx,
+    )).rejects.toThrow(
+      "Restrictions can only keep tools active in the parent. Unavailable: write.",
+    );
+    expect(rpc.invocations).toHaveLength(1);
+
+    await tools.get("subagent_start").execute(
+      "empty",
+      { prompt: "three", tools: [] },
+      undefined,
+      undefined,
+      ctx,
+    );
+    expect(rpc.invocations[1].args).toContain("--no-tools");
+  });
+
+  it("rejects start and continuation capability mismatches before prompt acceptance", async () => {
+    const { tools, ctx } = setup();
+    rpc.capabilityReports.push({
+      tools: [{ name: "read", provider: "builtin" }],
+      extensionPaths: [],
+    });
+
+    await expect(tools.get("subagent_start").execute(
+      "start",
+      { prompt: "not accepted" },
+      undefined,
+      undefined,
+      ctx,
+    )).rejects.toThrow("bash (expected builtin, missing)");
+    expect(rpc.children[0].requests).not.toContainEqual(
+      expect.objectContaining({ type: "prompt" }),
+    );
+    expect(rpc.children[0].closed).toBe(true);
+
+    rpc.capabilityReports.push({
+      tools: ["read", "bash", "edit", "write"].map((name) => ({ name, provider: "builtin" })),
+      extensionPaths: [],
+    });
+    await tools.get("subagent_start").execute(
+      "accepted",
+      { prompt: "one" },
+      undefined,
+      undefined,
+      ctx,
+    );
+    await settle(1);
+
+    rpc.capabilityReports.push({
+      tools: [{ name: "read", provider: "builtin" }],
+      extensionPaths: [],
+    });
+    await expect(tools.get("subagent_continue").execute(
+      "continue",
+      { id: 2, prompt: "not accepted either" },
+      undefined,
+      undefined,
+      ctx,
+    )).rejects.toThrow("bash (expected builtin, missing)");
+    expect(rpc.children[2].requests).not.toContainEqual(
+      expect.objectContaining({ type: "prompt" }),
+    );
+    expect(rpc.children[2].closed).toBe(true);
   });
 
   it("exposes opt-in routing schemas and default-routing guidance", () => {

--- a/extensions/subagents/native-inheritance.test.ts
+++ b/extensions/subagents/native-inheritance.test.ts
@@ -1,0 +1,238 @@
+import { mkdtemp, mkdir, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { CapabilitySnapshot } from "./capabilities.ts";
+import { SubagentController } from "./controller.ts";
+import { buildChildInvocation, RpcSubprocess } from "./rpc-child.ts";
+
+const PI_CLI = resolve("node_modules/@earendil-works/pi-coding-agent/dist/cli.js");
+const temporaryRoots: string[] = [];
+
+const PROVIDER_EXTENSION = String.raw`
+import { appendFileSync } from "node:fs";
+import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+
+function usage() {
+  return {
+    input: 1,
+    output: 1,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 2,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+}
+
+function streamFixture(model, context) {
+  appendFileSync(process.env.OMPI_FIXTURE_CAPTURE, JSON.stringify({
+    cwd: process.cwd(),
+    environment: process.env.OMPI_INHERITED_ENV,
+    systemPrompt: context.systemPrompt,
+    messages: context.messages,
+    tools: context.tools?.map((tool) => tool.name),
+  }) + "\n");
+  const stream = createAssistantMessageEventStream();
+  const partial = {
+    role: "assistant",
+    content: [],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: usage(),
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+  const message = {
+    ...partial,
+    content: [{ type: "text", text: "fixture done" }],
+  };
+  queueMicrotask(() => {
+    stream.push({ type: "start", partial });
+    stream.push({ type: "text_start", contentIndex: 0, partial });
+    stream.push({ type: "text_delta", contentIndex: 0, delta: "fixture done", partial: message });
+    stream.push({ type: "text_end", contentIndex: 0, content: "fixture done", partial: message });
+    stream.push({ type: "done", reason: "stop", message });
+    stream.end(message);
+  });
+  return stream;
+}
+
+export default function fixtureProvider(pi) {
+  pi.registerTool({
+    name: "fixture_tool",
+    label: "Fixture Tool",
+    description: "Deterministic inherited extension tool",
+    parameters: Type.Object({}),
+    async execute() {
+      return { content: [{ type: "text", text: "fixture tool" }] };
+    },
+  });
+  pi.registerProvider("fixture", {
+    name: "Fixture",
+    baseUrl: "http://fixture.invalid",
+    apiKey: "fixture-key",
+    api: "fixture-api",
+    models: [{
+      id: "model",
+      name: "Fixture Model",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 32000,
+      maxTokens: 1024,
+    }],
+    streamSimple: streamFixture,
+  });
+}
+`;
+
+function userText(entry: any): string | undefined {
+  if (entry.type !== "message" || entry.message?.role !== "user") return undefined;
+  const content = entry.message.content;
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return undefined;
+  return content
+    .filter((item) => item?.type === "text")
+    .map((item) => item.text)
+    .join("");
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("native child inheritance", () => {
+  it("keeps a clean native conversation while inheriting extension tools, skills, context, cwd, and environment", async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), "ompi-subagent-inheritance-"));
+    temporaryRoots.push(temporaryRoot);
+    const root = await realpath(temporaryRoot);
+    const agentDir = join(root, "agent");
+    const cwd = join(root, "project");
+    const skillDir = join(cwd, ".pi", "skills", "fixture-skill");
+    const providerPath = join(root, "fixture-provider.ts");
+    const capturePath = join(root, "captures.jsonl");
+    await mkdir(agentDir, { recursive: true });
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(agentDir, "settings.json"), JSON.stringify({ defaultProjectTrust: "always" }));
+    await writeFile(join(cwd, "AGENTS.md"), "PROJECT_CONTEXT_MARKER\n");
+    await writeFile(join(skillDir, "SKILL.md"), [
+      "---",
+      "name: fixture-skill",
+      "description: SKILL_DISCOVERY_MARKER for deterministic inheritance",
+      "---",
+      "",
+      "# Fixture Skill",
+    ].join("\n"));
+    await writeFile(providerPath, PROVIDER_EXTENSION);
+
+    const previous = {
+      agentDir: process.env.PI_CODING_AGENT_DIR,
+      sessionDir: process.env.PI_CODING_AGENT_SESSION_DIR,
+      offline: process.env.PI_OFFLINE,
+      skipVersion: process.env.PI_SKIP_VERSION_CHECK,
+      capture: process.env.OMPI_FIXTURE_CAPTURE,
+      inherited: process.env.OMPI_INHERITED_ENV,
+    };
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    process.env.PI_CODING_AGENT_SESSION_DIR = join(root, "sessions");
+    process.env.PI_OFFLINE = "1";
+    process.env.PI_SKIP_VERSION_CHECK = "1";
+    process.env.OMPI_FIXTURE_CAPTURE = capturePath;
+    process.env.OMPI_INHERITED_ENV = "ENVIRONMENT_MARKER";
+
+    const capabilities: CapabilitySnapshot = {
+      tools: [
+        { name: "read", provider: "builtin" },
+        { name: "fixture_tool", provider: providerPath },
+      ],
+      extensionPaths: [providerPath],
+    };
+    const controller = new SubagentController({
+      handshakeMs: 10_000,
+      createChild: async (spec) => {
+        const invocation = buildChildInvocation(spec);
+        return new RpcSubprocess({
+          ...invocation,
+          command: process.execPath,
+          args: [PI_CLI, ...invocation.args],
+        });
+      },
+      onPong: () => {
+        throw new Error("Direct integration runs must not emit pongs.");
+      },
+    });
+
+    try {
+      const first = await controller.run({
+        prompt: "EXPLICIT_FIRST",
+        cwd,
+        model: "fixture/model",
+        thinking: "off",
+        capabilities,
+        name: "named-only",
+      });
+      expect(first.outcome).toBe("completed");
+
+      const second = await controller.runContinuation({
+        id: 1,
+        prompt: "EXPLICIT_SECOND",
+        model: "fixture/model",
+        thinking: "off",
+        capabilities,
+      });
+      expect(second).toMatchObject({
+        outcome: "completed",
+        sessionRef: first.sessionRef,
+      });
+
+      const sessionLines = (await readFile(first.sessionRef, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      expect(sessionLines[0]).toMatchObject({ type: "session", cwd });
+      expect(sessionLines[0]).not.toHaveProperty("parentSession");
+      expect(sessionLines.map(userText).filter(Boolean)).toEqual([
+        "EXPLICIT_FIRST",
+        "EXPLICIT_SECOND",
+      ]);
+      const serializedSession = JSON.stringify(sessionLines);
+      expect(serializedSession).not.toContain("PARENT_TRANSCRIPT_MARKER");
+      expect(serializedSession).not.toContain("compactionSummary");
+      expect(serializedSession).not.toContain("worker subagent");
+
+      const captures = (await readFile(capturePath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      expect(captures).toHaveLength(2);
+      for (const capture of captures) {
+        expect(capture.cwd).toBe(cwd);
+        expect(capture.environment).toBe("ENVIRONMENT_MARKER");
+        expect(capture.systemPrompt).toContain("PROJECT_CONTEXT_MARKER");
+        expect(capture.systemPrompt).toContain("SKILL_DISCOVERY_MARKER");
+        expect(capture.systemPrompt).not.toContain("worker subagent");
+        expect(capture.tools).toEqual(["read", "fixture_tool"]);
+      }
+      expect(captures[0].messages.map((message: any) => message.role)).toEqual(["user"]);
+      expect(captures[1].messages.map((message: any) => message.role)).toEqual([
+        "user",
+        "assistant",
+        "user",
+      ]);
+    } finally {
+      await controller.shutdown();
+      const restore = (name: string, value: string | undefined) => {
+        if (value === undefined) delete process.env[name];
+        else process.env[name] = value;
+      };
+      restore("PI_CODING_AGENT_DIR", previous.agentDir);
+      restore("PI_CODING_AGENT_SESSION_DIR", previous.sessionDir);
+      restore("PI_OFFLINE", previous.offline);
+      restore("PI_SKIP_VERSION_CHECK", previous.skipVersion);
+      restore("OMPI_FIXTURE_CAPTURE", previous.capture);
+      restore("OMPI_INHERITED_ENV", previous.inherited);
+    }
+  }, 20_000);
+});

--- a/extensions/subagents/rpc-child.test.ts
+++ b/extensions/subagents/rpc-child.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { BUILTIN_TOOL_PROVIDER } from "./capabilities.ts";
 import { buildChildInvocation } from "./rpc-child.ts";
 
 function valueAfter(args: string[], flag: string): string | undefined {
@@ -6,45 +7,56 @@ function valueAfter(args: string[], flag: string): string | undefined {
   return index < 0 ? undefined : args[index + 1];
 }
 
+function valuesAfter(args: string[], flag: string): string[] {
+  return args.flatMap((value, index) => value === flag ? [args[index + 1]] : []);
+}
+
 describe("buildChildInvocation", () => {
-  it("creates a clean native Pi launch with inherited environment and explicit user skills", () => {
+  it("creates a clean Pi launch with exact tools, required providers, and normal resource discovery", () => {
     const invocation = buildChildInvocation({
       cwd: "/tmp/worktree",
       model: "anthropic/claude",
       thinking: "high",
-      tools: ["read", "bash"],
+      capabilities: {
+        tools: [
+          { name: "read", provider: BUILTIN_TOOL_PROVIDER },
+          { name: "browser_fetch", provider: "/extensions/browser-fetch/index.ts" },
+        ],
+        extensionPaths: ["/extensions/browser-fetch/index.ts"],
+      },
       name: "audit",
-    }, "/home/user/.pi/agent/skills");
+    });
 
     expect(invocation.cwd).toBe("/tmp/worktree");
     expect(invocation.env.PATH).toBe(process.env.PATH);
     expect(invocation.args).toContain("--no-extensions");
-    expect(invocation.args).toContain("--no-skills");
-    expect(valueAfter(invocation.args, "--skill")).toBe("/home/user/.pi/agent/skills");
-    expect(valueAfter(invocation.args, "--append-system-prompt")).toContain(
-      "You are a worker subagent",
-    );
-    expect(valueAfter(invocation.args, "--append-system-prompt")).toContain(
-      "Do not spawn or delegate to other agents",
-    );
+    expect(valuesAfter(invocation.args, "--extension")).toEqual([
+      "/extensions/browser-fetch/index.ts",
+      expect.stringMatching(/capability-probe\.ts$/),
+    ]);
+    expect(invocation.args).not.toContain("--no-skills");
+    expect(invocation.args).not.toContain("--skill");
+    expect(invocation.args).not.toContain("--append-system-prompt");
     expect(valueAfter(invocation.args, "--model")).toBe("anthropic/claude");
     expect(valueAfter(invocation.args, "--thinking")).toBe("high");
-    expect(valueAfter(invocation.args, "--tools")).toBe("read,bash");
+    expect(valueAfter(invocation.args, "--tools")).toBe("read,browser_fetch");
     expect(valueAfter(invocation.args, "--name")).toBe("audit");
     expect(invocation.args).not.toContain("--no-context-files");
   });
 
-  it("resumes the native session without trying to rename it or restricting default tools", () => {
+  it("resumes only the native session and can preserve an explicitly empty snapshot", () => {
     const invocation = buildChildInvocation({
       cwd: "/tmp/worktree",
       model: "openai/gpt",
       thinking: "low",
+      capabilities: { tools: [], extensionPaths: [] },
       name: "existing",
       session: "/sessions/child.jsonl",
-    }, "/skills");
+    });
 
     expect(valueAfter(invocation.args, "--session")).toBe("/sessions/child.jsonl");
     expect(invocation.args).not.toContain("--name");
+    expect(invocation.args).toContain("--no-tools");
     expect(invocation.args).not.toContain("--tools");
   });
 });

--- a/extensions/subagents/rpc-child.ts
+++ b/extensions/subagents/rpc-child.ts
@@ -2,6 +2,12 @@ import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { existsSync } from "node:fs";
 import { basename } from "node:path";
 import { StringDecoder } from "node:string_decoder";
+import { fileURLToPath } from "node:url";
+import {
+  CAPABILITY_PROBE_STATUS_KEY,
+  parseCapabilityProbe,
+  type CapabilitySnapshot,
+} from "./capabilities.ts";
 import type { LaunchSpec, RpcChild, RpcEvent } from "./controller.ts";
 
 interface RpcResponse {
@@ -18,11 +24,7 @@ interface PendingRequest {
   timer: NodeJS.Timeout;
 }
 
-const WORKER_SYSTEM_PROMPT = [
-  "You are a worker subagent in a conversation orchestrated by a parent agent.",
-  "Complete the assigned task yourself and report the result to the parent.",
-  "Do not spawn or delegate to other agents, Pi processes, or tmux workers, including through shell commands or skills.",
-].join(" ");
+const CAPABILITY_PROBE_PATH = fileURLToPath(new URL("./capability-probe.ts", import.meta.url));
 
 export interface ChildInvocation {
   command: string;
@@ -31,19 +33,21 @@ export interface ChildInvocation {
   env: NodeJS.ProcessEnv;
 }
 
-export function buildChildInvocation(spec: LaunchSpec, userSkillsDir: string): ChildInvocation {
-  const args = [
-    "--mode", "rpc",
-    "--no-extensions",
-    "--no-skills",
-    "--skill", userSkillsDir,
-    "--append-system-prompt", WORKER_SYSTEM_PROMPT,
+export function buildChildInvocation(spec: LaunchSpec): ChildInvocation {
+  const args = ["--mode", "rpc", "--no-extensions"];
+  for (const extensionPath of spec.capabilities.extensionPaths) {
+    args.push("--extension", extensionPath);
+  }
+  args.push(
+    "--extension", CAPABILITY_PROBE_PATH,
     "--model", spec.model,
     "--thinking", spec.thinking,
-  ];
+  );
   if (spec.session) args.push("--session", spec.session);
   if (spec.name && !spec.session) args.push("--name", spec.name);
-  if (spec.tools !== undefined) args.push("--tools", spec.tools.join(","));
+  const tools = spec.capabilities.tools.map((tool) => tool.name);
+  if (tools.length > 0) args.push("--tools", tools.join(","));
+  else args.push("--no-tools");
 
   const currentScript = process.argv[1];
   const isBunVirtualScript = currentScript?.startsWith("/$bunfs/root/");
@@ -71,11 +75,19 @@ export class RpcSubprocess implements RpcChild {
   private exited = false;
   private exitPromise: Promise<void>;
   private resolveExit!: () => void;
+  private readonly capabilitiesPromise: Promise<CapabilitySnapshot>;
+  private resolveCapabilities!: (snapshot: CapabilitySnapshot) => void;
+  private rejectCapabilities!: (error: Error) => void;
 
   constructor(invocation: ChildInvocation) {
     this.exitPromise = new Promise((resolve) => {
       this.resolveExit = resolve;
     });
+    this.capabilitiesPromise = new Promise((resolve, reject) => {
+      this.resolveCapabilities = resolve;
+      this.rejectCapabilities = reject;
+    });
+    void this.capabilitiesPromise.catch(() => undefined);
     this.process = spawn(invocation.command, invocation.args, {
       cwd: invocation.cwd,
       env: invocation.env,
@@ -96,6 +108,10 @@ export class RpcSubprocess implements RpcChild {
     this.process.stdin.on("error", (error) => {
       if (!this.exited) this.rejectPending(error);
     });
+  }
+
+  getCapabilities(): Promise<CapabilitySnapshot> {
+    return this.capabilitiesPromise;
   }
 
   request(command: Record<string, unknown>): Promise<unknown> {
@@ -172,6 +188,22 @@ export class RpcSubprocess implements RpcChild {
     } catch {
       return;
     }
+    if (
+      message.type === "extension_ui_request"
+      && "method" in message
+      && message.method === "setStatus"
+      && "statusKey" in message
+      && message.statusKey === CAPABILITY_PROBE_STATUS_KEY
+    ) {
+      try {
+        this.resolveCapabilities(parseCapabilityProbe(
+          "statusText" in message ? message.statusText : undefined,
+        ));
+      } catch (error) {
+        this.rejectCapabilities(error instanceof Error ? error : new Error(String(error)));
+      }
+      return;
+    }
     if (message.type === "response" && "id" in message && message.id) {
       const pending = this.pending.get(message.id);
       if (!pending) return;
@@ -187,7 +219,9 @@ export class RpcSubprocess implements RpcChild {
   private handleExit(error?: Error): void {
     if (this.exited) return;
     this.exited = true;
-    this.rejectPending(error ?? new Error("Child RPC process exited."));
+    const exitError = error ?? new Error("Child RPC process exited.");
+    this.rejectCapabilities(exitError);
+    this.rejectPending(exitError);
     this.resolveExit();
     for (const listener of this.exitListeners) listener(error);
   }


### PR DESCRIPTION
## Summary

- inherit the parent’s then-active built-in and extension tools on every start and continuation
- load only required extension providers and reject capability mismatches before prompt acceptance
- restore normal skill and repository-instruction discovery while keeping child conversations isolated
- enforce monotonic tool narrowing with role-neutral behavior
- document the inherited runtime baseline and add deterministic/native-process coverage

## Verification

- `npm test` — 18 files, 135 tests passed
- `npm run typecheck` — passed
- `git diff --check d77eae4e659dcf821f201ac376bd1ecf9da41e31...HEAD` — passed
- isolated read-only review — ready; two non-blocking diagnostics/error-context observations corrected by the coordinator

Closes #26
