### PR TITLE
feat: run bounded nested subagent turns

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,17 +377,19 @@ or administer OMQueue.
 `just subagents` explicitly enables the extension in
 `extensions/subagents/`. It starts clean, persistent Pi conversations. In print
 mode, start and continuation tool calls wait for terminal completion and return
-the bounded result directly; independent sibling calls still run concurrently.
-In other modes, each call returns as soon as the child RPC process accepts a
-prompt, then later queues exactly one completion, failure, or interruption pong
-in the orchestrator conversation.
+the bounded result directly. Outside print mode, asynchronous delivery remains
+the default: a call returns after child RPC prompt acceptance and later queues
+exactly one completion, failure, or interruption pong. Set `delivery` to
+`"direct"` explicitly when dependent work must receive the bounded terminal
+result through the pending tool call; direct delivery emits no later pong.
+Independent direct siblings issued together still run concurrently.
 
-Outside print mode, after acceptance the orchestrator must not sleep, run a wait
-loop, or repeatedly call `subagent_list` for completion. When multiple independent
+After asynchronous acceptance, the parent must not sleep, run a wait loop, or
+repeatedly call `subagent_list` for completion. When multiple independent
 delegations are useful, it starts them in the same turn so Pi can run them
 concurrently rather than awaiting an earlier pong. It may then continue useful
 work independent of the subagent results; otherwise it must end its response so
-user input and the later pongs can enter the conversation.
+user input and later pongs can enter the conversation.
 
 For daily use, link this audited extension into Pi's global extension directory:
 
@@ -410,8 +412,9 @@ The extension exposes these tools and matching commands:
 | `subagent_list` | `/sublist` | List session-scoped known conversations |
 
 Use plain command arguments for common operations, or JSON with `/sub` and
-`/subcont` for routing, working-directory, tool, and name options. Each omitted
-routing value inherits the orchestrator's active value when that turn is
+`/subcont` for delivery, lineage ceilings, routing, working-directory, tool, and
+name options. Each omitted routing value inherits the parent's active value when
+that turn is
 dispatched. An explicit `model` override must use the qualified
 `provider/model` form; bare or malformed values are rejected before child
 launch. Optional `model` and `reasoning` overrides apply to one dispatch only
@@ -420,12 +423,17 @@ live subagent widget and `/sublist` output show the effective routing values.
 At each start or continuation, omitted `tools` inherit the parent's full
 then-active set, including extension tools; an explicit array can only narrow
 that snapshot, and `tools: []` selects no tools. A subagent name is descriptive
-and does not silently change capabilities. For example:
+and does not silently change capabilities or delivery. `maxDepth` and
+`maxChildren` may tighten the child's inherited managed-lineage ceilings; a
+continuation keeps the same depth and may tighten its prior ceilings again, but
+neither value can be raised. For example:
 
 ```text
 /sub Inspect the authentication flow and report risks.
 /sub {"prompt":"Run the focused tests","name":"tests","tools":["read","bash"]}
 /sub {"prompt":"Inspect memory handling","model":"openai-codex/gpt-5.6-luna","reasoning":"high"}
+/sub {"prompt":"Return a dependent result now","delivery":"direct","maxDepth":2,"maxChildren":0}
+/subcont {"id":1,"prompt":"Continue and return here","delivery":"direct"}
 /subcont 1 Check the newly changed files.
 /substeer 1 Focus only on the parser.
 /substop 1
@@ -441,10 +449,25 @@ the child working directory.
 
 A fresh child stores only its explicit prompt in a new native Pi JSONL
 conversation; it never imports the parent transcript, summaries, or hidden
-continuation state. Continuation resumes only that child's conversation while
-capturing the parent's current capabilities again. At most twelve child
-processes run at once. The registry is intentionally in memory; native Pi JSONL
-sessions remain after the orchestrator exits.
+continuation state. Continuation resumes only that child's conversation at the
+same one-based delegation depth while capturing the parent's current
+capabilities again. The root is depth 1, its coordinator is depth 2, a leaf is
+depth 3, and the default maximum is 3. The root owns at most 12 active direct
+children; each nested parent defaults to 2. Handshaking, running, finalizing,
+and direct-wait runtimes occupy the responsible parent's local slot until their
+process exits.
+
+A coordinator RPC process remains alive through dependent direct leaf calls and
+exits only after its enclosing Pi turn settles. Parent interruption, process
+closure, and session shutdown recursively close active descendants created
+through this extension and await their process exit. Independently shell-launched
+Pi or other processes are outside that managed lineage. Caller-requested
+interruption returns the distinct `interrupted` terminal outcome rather than a
+spontaneous `failed` outcome. Every bounded terminal result retains the native
+session reference for complete inspection, including truncated, failed,
+interrupted, and missing-assistant-message cases. The registry is intentionally
+in memory; native Pi JSONL sessions remain after processes and the orchestrator
+exit.
 
 Install dependencies and verify the extension with:
 

--- a/docs/subagents/CONTEXT.md
+++ b/docs/subagents/CONTEXT.md
@@ -5,27 +5,55 @@ Language for the small internal Pi extension that lets one conversation start an
 ## Language
 
 **Orchestrator agent**:
-The Pi agent conversation that delegates work to subagents, receives their pongs, and decides what happens next.
+The root Pi agent conversation in one extension-managed delegation lineage. It delegates work, receives asynchronous pongs or direct terminal results, and decides what happens next.
 _Avoid_: Product, service, platform, mechanical controller
 
+**Parent agent**:
+The agent conversation that directly starts a subagent. A parent may itself be a subagent; the orchestrator is the root parent at delegation depth 1.
+_Avoid_: Manager process, supervisor service
+
 **Subagent**:
-An independent Pi agent conversation started by the orchestrator agent and owned by its current session. Its conversation persists across turns, while its process exists only during an active turn.
-_Avoid_: Worker service, task, job
+An independent headless Pi agent conversation started by its parent and owned by that parent's current session. Its native Pi JSONL conversation persists across turns, while one RPC process exists only during an accepted active turn.
+_Avoid_: Worker service, task, job, daemon
+
+**Headless child runtime**:
+The live RPC process that hosts one subagent turn with its normal Pi agent loop, inherited tools and extension providers, and managed descendants but no TUI. It remains alive through every model and tool step in that turn, including direct nested delegations, then exits after terminal settlement or parent-requested closure. A later continuation starts another process over the preserved native session at the same delegation depth.
+_Avoid_: Detached daemon, TUI pane, persistent idle service
+
+**Direct runtime owner**:
+The parent agent that opened one active headless child runtime. Each parent owns only its direct extension-managed children; ancestor closure cascades through that ownership chain, while normal process exit ends ownership automatically.
+_Avoid_: Semantic task owner, remote lifecycle controller, shell-process owner
 
 **Inherited runtime baseline**:
-The orchestrator's active operating environment projected into a subagent by default: active Pi and extension tools, the extension providers required to reproduce those tools, normal skill discovery, applicable repository instructions, working directory, routing defaults, and environment. Inheritance is launch mechanics rather than a model-visible negotiation tool. Explicit caller restrictions are opt-in; omission means inherit the baseline.
+The parent's active operating environment projected into a subagent by default: active Pi and extension tools, the extension providers required to reproduce those tools, normal skill discovery, applicable repository instructions, working directory, routing defaults, and environment. Inheritance is launch mechanics rather than a model-visible negotiation tool. Explicit caller restrictions are opt-in; omission means inherit the baseline.
 _Avoid_: Conversation fork, ambient extension discovery, role profile, inheritance prompt
 
 **Capability snapshot**:
-The exact set of tools active in the orchestrator when a start or continuation dispatch is accepted. A subagent inherits this snapshot by default, including extension tools, without gaining inactive or undiscovered tools. The caller may explicitly narrow the snapshot; assigning a writer, reviewer, or other name does not silently change it. Required provider loading and validation happen mechanically before prompt acceptance.
+The exact set of tools active in the parent when a start or continuation dispatch is accepted. A subagent inherits this snapshot by default, including extension tools, without gaining inactive or undiscovered tools. The caller may explicitly narrow the snapshot; assigning a writer, reviewer, coordinator, or other name does not silently change it. Required provider loading and validation happen mechanically before prompt acceptance.
 _Avoid_: Installed tool catalog, role profile, automatic capability discovery
 
+**Delegation depth**:
+The one-based position of an agent in one managed delegation lineage: root orchestrator 1, coordinator 2, and leaf 3 by default. The default maximum is 3. Continuation preserves a subagent's depth. An agent at its maximum keeps the subagent tools available, but a further start is rejected before process launch. A caller may tighten the inherited maximum for a child or later continuation but cannot raise it.
+_Avoid_: Process count, task phase, permission role
+
+**Direct active-child ceiling**:
+The maximum number of direct child processes one parent may own concurrently. The root default is 12 and a nested parent defaults to 2. A nested ceiling may be tightened to 0, 1, or 2 but never raised above what the parent inherited. Handshaking, running, finalizing, and direct-wait runtimes hold a local slot until their owned process has exited. Each controller enforces only its direct children; this is not a global or tree-wide semaphore.
+_Avoid_: Global process limit, queue capacity, lifetime spawn count, known conversation count
+
+**Managed delegation lineage**:
+The parent-child process tree created through this subagent extension. Parent interruption, direct runtime closure, and session shutdown recursively close active descendants and await owned process exit. Pi or other processes launched independently through shell tools remain outside this lineage and are not intercepted or claimed by the extension.
+_Avoid_: Operating-system process tree, process sandbox, security boundary
+
+**Runtime closure**:
+The direct parent's termination of an active headless child runtime. Closure interrupts its current turn, cascades through managed descendants, confirms owned process exit before releasing local capacity, and preserves native session files for inspection or continuation.
+_Avoid_: Session deletion, semantic completion, idle release
+
 **Clean start**:
-A new subagent conversation that receives the inherited runtime baseline and its explicit prompt but none of the orchestrator transcript, compaction summary, hidden continuation state, or prior messages. A continuation preserves only that subagent's native Pi conversation; runtime inheritance never implies conversation sharing.
+A new subagent conversation that receives the inherited runtime baseline and its explicit prompt but none of the parent transcript, compaction summary, hidden continuation state, or prior messages. A continuation preserves only that subagent's native Pi conversation; runtime inheritance never implies conversation sharing.
 _Avoid_: Context fork, implicit transcript inheritance, automatic conversation sharing
 
 **Subagent extension**:
-The mechanical Pi extension that connects the orchestrator agent to subagents and owns their process lifecycle, message transport, and status for the current session. It does not decide or interpret delegated work.
+The mechanical Pi extension that connects each parent agent to direct subagents and owns their managed process lifecycle, message transport, local limits, and status for the current session. It does not decide or interpret delegated work.
 _Avoid_: Agent, daemon, orchestration platform, scheduler, workflow engine
 
 **Steering**:
@@ -33,16 +61,24 @@ A new instruction queued for a running subagent and delivered at Pi's next safe 
 _Avoid_: Real-time chat, process interruption, follow-up
 
 **Interruption**:
-Aborting a subagent's current turn without deleting its conversation, so that conversation remains available for later instructions.
-_Avoid_: Removal, reset, steering
+Aborting a subagent's current turn without deleting its conversation, so that conversation remains available for later instructions. A matching caller-requested interruption produces the mechanically distinct `interrupted` terminal outcome; a spontaneous process or provider failure remains `failed`, even when no current-turn assistant message exists.
+_Avoid_: Removal, reset, steering, generic failure
+
+**Delivery mode**:
+The caller-selected return contract for one dispatch. `async` is the default outside print mode: acceptance returns immediately and terminal settlement produces one later pong. Explicit `direct` keeps the tool call pending and returns one bounded terminal result without a later pong. Print mode is always direct. Role, name, and delegation depth never select direct delivery implicitly.
+_Avoid_: Coordinator profile, leaf profile, hidden topology mode
+
+**Terminal result**:
+The mechanically classified `completed`, `failed`, or `interrupted` outcome of one bounded subagent turn. It includes the current turn's bounded final assistant text when one exists and always retains the native session reference needed to inspect complete persisted evidence after truncation, failure, interruption, or a missing assistant message.
+_Avoid_: Workflow decision, semantic success, transcript copy
 
 **Start confirmation**:
-The immediate response that a subagent process accepted its prompt and began an active turn. It does not wait for that turn to finish.
+The immediate response that a subagent process accepted an asynchronous prompt and began an active turn. It does not wait for that turn to finish.
 _Avoid_: Pong, completion
 
 **Pong**:
-The subagent extension's single deterministic notification that an accepted subagent turn completed, failed, or was interrupted. It includes the subagent's bounded final assistant message when one exists and a reference to the full conversation; its delivery never depends on the subagent producing that message.
-_Avoid_: Model callback, polling, status check
+The subagent extension's single deterministic asynchronous notification that an accepted subagent turn completed, failed, or was interrupted. It carries the bounded terminal result and its native session reference; delivery never depends on the subagent producing an assistant message. Direct delivery never emits a pong.
+_Avoid_: Direct result, model callback, polling, status check
 
 **Live status**:
 A compact Pi widget near the editor that shows current subagent activity without adding streaming updates to the orchestrator conversation. A minimal footer count remains visible while any subagent turn is active. The same active count is published through the shared extension event bus so session-level status integrations do not mistake a settled orchestrator turn for an idle session.
@@ -51,17 +87,23 @@ _Avoid_: Transcript message, progress polling, full output
 ## Routing selection
 
 Every clean start and continuation independently inherits each omitted routing
-value from the orchestrator's active model and current Pi thinking level when
-that turn is dispatched. Agent-facing tools and command JSON may provide an
+value from the parent's active model and current Pi thinking level when that
+turn is dispatched. Agent-facing tools and command JSON may provide an
 explicit model override only as a qualified `provider/model` selector, such as
 `openai-codex/gpt-5.6-luna`. Bare or malformed model overrides are rejected
 before child launch. A supported `reasoning` level may also be provided for that
-dispatch only. The orchestrator agent must omit these overrides unless the user
+dispatch only. The parent agent must omit these overrides unless the user
 explicitly requests that routing. An override never becomes a default for later
 continuations.
 
 ## Mode contract
 
-In print mode, start and continuation tool calls remain pending until their subagent turns reach a terminal outcome, then return the bounded terminal result directly without a pong. Independent sibling delegations still run concurrently as one tool batch; dependent work continues in the next model turn after that batch completes. Caller cancellation interrupts the active direct subagent turn.
+In print mode, start and continuation tool calls remain pending until their subagent turns reach a terminal outcome, then return the bounded terminal result directly without a pong. Outside print mode, asynchronous delivery remains the default and `delivery: "direct"` must be selected explicitly for dependent work. Independently issued direct sibling calls still run concurrently. Caller cancellation interrupts the matching active direct runtime and returns `interrupted` with its native session reference.
 
-Outside print mode, after a start confirmation the orchestrator must never keep its current turn alive merely to await the pong. It must not use sleeps, shell wait loops, or repeated status snapshots. When multiple independent delegations are useful, it starts their subagent calls without awaiting earlier pongs so Pi can run sibling tool calls concurrently. It may then continue useful work that does not depend on the subagents' results; otherwise it ends its response immediately. Ending the response returns control to the user and lets the queued pongs enter the orchestrator conversation in later turns.
+After an asynchronous start confirmation, the parent must never keep its current turn alive merely to await the pong. It must not use sleeps, shell wait loops, or repeated status snapshots. When multiple independent delegations are useful, it starts their subagent calls without awaiting earlier pongs so Pi can run sibling tool calls concurrently. It may then continue useful work that does not depend on the subagents' results; otherwise it ends its response immediately. Ending the response returns control to the caller and lets queued pongs enter the parent conversation in later turns.
+
+A depth-2 parent remains alive while dependent direct depth-3 tool calls run and exits only after its enclosing Pi turn settles. Its native session persists for later inspection or continuation; the extension adds no persistent idle runtime or workflow store. Runtime closure and session shutdown recursively clean only the active managed lineage.
+
+## Root session boundary
+
+The subagent extension does not replace, rotate, or automatically continue the root native Pi session. Pi's user-initiated session operations keep their existing contracts, and one print-mode invocation retains one root conversation until it terminates.

--- a/extensions/subagents/controller.test.ts
+++ b/extensions/subagents/controller.test.ts
@@ -5,6 +5,7 @@ import {
   type RpcChild,
   type RpcEvent,
 } from "./controller.ts";
+import type { ManagedLineage } from "./lineage.ts";
 import {
   BUILTIN_TOOL_PROVIDER,
   cloneCapabilities,
@@ -26,6 +27,8 @@ class FakeChild implements RpcChild {
   private exitListeners: Array<(error?: Error) => void> = [];
   private promptGate?: Promise<void>;
   private releasePrompt?: () => void;
+  private closeGate?: Promise<void>;
+  private releaseClose?: () => void;
   private readonly reportedCapabilities?: CapabilitySnapshot;
 
   constructor(
@@ -33,6 +36,7 @@ class FakeChild implements RpcChild {
     sessionFile: string,
     delayedPrompt = false,
     reportedCapabilities?: CapabilitySnapshot,
+    delayedClose = false,
   ) {
     this.spec = spec;
     this.sessionFile = sessionFile;
@@ -42,10 +46,19 @@ class FakeChild implements RpcChild {
         this.releasePrompt = resolve;
       });
     }
+    if (delayedClose) {
+      this.closeGate = new Promise((resolve) => {
+        this.releaseClose = resolve;
+      });
+    }
   }
 
   acceptPrompt(): void {
     this.releasePrompt?.();
+  }
+
+  allowExit(): void {
+    this.releaseClose?.();
   }
 
   async request(command: Record<string, unknown>): Promise<unknown> {
@@ -83,6 +96,7 @@ class FakeChild implements RpcChild {
   }
 
   async close(): Promise<void> {
+    await this.closeGate;
     this.closed = true;
   }
 }
@@ -91,17 +105,21 @@ function setup(options: {
   delayedPrompt?: boolean;
   handshakeMs?: number;
   reportedCapabilities?: CapabilitySnapshot;
+  lineage?: ManagedLineage;
+  delayedClose?: boolean;
 } = {}) {
   const children: FakeChild[] = [];
   const pongs: unknown[] = [];
   const controller = new SubagentController({
     handshakeMs: options.handshakeMs ?? 100,
+    lineage: options.lineage,
     createChild: async (spec) => {
       const child = new FakeChild(
         spec,
         `/sessions/${children.length + 1}.jsonl`,
         options.delayedPrompt,
         options.reportedCapabilities,
+        options.delayedClose,
       );
       children.push(child);
       return child;
@@ -112,6 +130,9 @@ function setup(options: {
 }
 
 async function settle(child: FakeChild): Promise<void> {
+  if (child.finalText !== null) {
+    child.emit({ type: "message_end", message: { role: "assistant", stopReason: "stop" } });
+  }
   child.emit({ type: "agent_settled" });
   await vi.waitFor(() => expect(child.closed).toBe(true));
 }
@@ -192,10 +213,205 @@ describe("SubagentController", () => {
     await vi.waitFor(() => expect(children).toHaveLength(1));
     cancellation.abort();
     await vi.waitFor(() => expect(children[0].requests).toContainEqual({ type: "abort" }));
+    children[0].finalText = "stale text from an earlier turn";
+    children[0].emit({ type: "agent_settled" });
+    await vi.waitFor(() => expect(children[0].closed).toBe(true));
+
+    const result = await running;
+    expect(result).toMatchObject({
+      outcome: "interrupted",
+      sessionRef: "/sessions/1.jsonl",
+    });
+    expect(result.finalText).toBeUndefined();
+    expect(pongs).toEqual([]);
+  });
+
+  it("rejects delegation beyond the inherited maximum depth before child launch", async () => {
+    const { controller, children } = setup({
+      lineage: { depth: 3, maxDepth: 3, maxChildren: 2 },
+    });
+
+    await expect(controller.start({
+      prompt: "too deep",
+      cwd: "/repo",
+      model: "p/m",
+      thinking: "low",
+      capabilities: DEFAULT_CAPABILITIES,
+    })).rejects.toThrow("maximum delegation depth 3");
+    expect(children).toEqual([]);
+  });
+
+  it("passes caller-tightened depth and child ceilings to the managed child", async () => {
+    const { controller, children } = setup();
+
+    await controller.start({
+      prompt: "coordinate without descendants",
+      cwd: "/repo",
+      model: "p/m",
+      thinking: "low",
+      capabilities: DEFAULT_CAPABILITIES,
+      maxDepth: 2,
+      maxChildren: 0,
+    });
+
+    expect(children[0].spec.lineage).toEqual({
+      depth: 2,
+      maxDepth: 2,
+      maxChildren: 0,
+    });
+  });
+
+  it("rejects a child ceiling above the nested parent's inherited ceiling before launch", async () => {
+    const { controller, children } = setup({
+      lineage: { depth: 2, maxDepth: 3, maxChildren: 1 },
+    });
+
+    await expect(controller.start({
+      prompt: "raise ceiling",
+      cwd: "/repo",
+      model: "p/m",
+      thinking: "low",
+      capabilities: DEFAULT_CAPABILITIES,
+      maxChildren: 2,
+    })).rejects.toThrow("0 through 1");
+    expect(children).toEqual([]);
+  });
+
+  it("keeps continuation depth stable and allows ceilings only to tighten", async () => {
+    const { controller, children } = setup();
+    const startInput = {
+      prompt: "one",
+      cwd: "/repo",
+      model: "p/m",
+      thinking: "low" as const,
+      capabilities: DEFAULT_CAPABILITIES,
+    };
+    await controller.start(startInput);
     await settle(children[0]);
 
-    await expect(running).resolves.toMatchObject({ outcome: "interrupted" });
-    expect(pongs).toEqual([]);
+    await controller.continue({
+      id: 1,
+      prompt: "two",
+      model: "p/m",
+      thinking: "low",
+      capabilities: DEFAULT_CAPABILITIES,
+      maxDepth: 2,
+      maxChildren: 1,
+    });
+    expect(children[1].spec.lineage).toEqual({ depth: 2, maxDepth: 2, maxChildren: 1 });
+    await settle(children[1]);
+
+    await expect(controller.continue({
+      id: 1,
+      prompt: "raise depth",
+      model: "p/m",
+      thinking: "low",
+      capabilities: DEFAULT_CAPABILITIES,
+      maxDepth: 3,
+    })).rejects.toThrow("cannot raise");
+    await expect(controller.continue({
+      id: 1,
+      prompt: "raise children",
+      model: "p/m",
+      thinking: "low",
+      capabilities: DEFAULT_CAPABILITIES,
+      maxChildren: 2,
+    })).rejects.toThrow("cannot raise");
+    expect(children).toHaveLength(2);
+  });
+
+  it("counts a handshaking child against the local ceiling", async () => {
+    const { controller, children } = setup({
+      lineage: { depth: 2, maxDepth: 3, maxChildren: 1 },
+      delayedPrompt: true,
+    });
+    const input = {
+      cwd: "/repo",
+      model: "p/m",
+      thinking: "low" as const,
+      capabilities: DEFAULT_CAPABILITIES,
+    };
+    const starting = controller.start({ ...input, prompt: "one" });
+    await vi.waitFor(() => expect(children).toHaveLength(1));
+
+    await expect(controller.start({ ...input, prompt: "two" })).rejects.toThrow(
+      "At most 1 direct subagents",
+    );
+    expect(children).toHaveLength(1);
+    children[0].acceptPrompt();
+    await starting;
+  });
+
+  it("counts a direct-wait child against the local ceiling", async () => {
+    const { controller, children } = setup({
+      lineage: { depth: 2, maxDepth: 3, maxChildren: 1 },
+    });
+    const input = {
+      cwd: "/repo",
+      model: "p/m",
+      thinking: "low" as const,
+      capabilities: DEFAULT_CAPABILITIES,
+    };
+    const running = controller.run({ ...input, prompt: "direct" });
+    await vi.waitFor(() => expect(controller.list()[0]).toMatchObject({
+      active: true,
+      state: "running",
+    }));
+
+    await expect(controller.start({ ...input, prompt: "too early" })).rejects.toThrow(
+      "At most 1 direct subagents",
+    );
+    await settle(children[0]);
+    await expect(running).resolves.toMatchObject({ outcome: "completed" });
+  });
+
+  it("releases a finalizing child's slot only after owned process exit", async () => {
+    const { controller, children } = setup({
+      lineage: { depth: 2, maxDepth: 3, maxChildren: 1 },
+      delayedClose: true,
+    });
+    const input = {
+      cwd: "/repo",
+      model: "p/m",
+      thinking: "low" as const,
+      capabilities: DEFAULT_CAPABILITIES,
+    };
+    await controller.start({ ...input, prompt: "one" });
+    children[0].emit({ type: "agent_settled" });
+    await vi.waitFor(() => expect(controller.list()[0]).toMatchObject({
+      active: true,
+      state: "finalizing",
+    }));
+
+    await expect(controller.start({ ...input, prompt: "too early" })).rejects.toThrow(
+      "At most 1 direct subagents",
+    );
+    children[0].allowExit();
+    await vi.waitFor(() => expect(controller.list()[0]?.active).toBe(false));
+    await expect(controller.start({ ...input, prompt: "after exit" })).resolves.toMatchObject({
+      state: "running",
+    });
+  });
+
+  it("enforces a nested parent's local two-child ceiling before launch", async () => {
+    const { controller, children } = setup({
+      lineage: { depth: 2, maxDepth: 3, maxChildren: 2 },
+    });
+    const input = {
+      cwd: "/repo",
+      model: "p/m",
+      thinking: "low" as const,
+      capabilities: DEFAULT_CAPABILITIES,
+    };
+
+    await Promise.all([
+      controller.start({ ...input, prompt: "one" }),
+      controller.start({ ...input, prompt: "two" }),
+    ]);
+    await expect(controller.start({ ...input, prompt: "three" })).rejects.toThrow(
+      "At most 2 direct subagents",
+    );
+    expect(children).toHaveLength(2);
   });
 
   it("runs twelve children and rejects a thirteenth without queuing", async () => {
@@ -258,6 +474,21 @@ describe("SubagentController", () => {
     children[0].crash("boom");
     await vi.waitFor(() => expect(pongs).toHaveLength(1));
     expect(pongs[0]).toMatchObject({ outcome: "failed", error: "boom" });
+  });
+
+  it("does not classify a spontaneous aborted assistant message as caller interruption", async () => {
+    const { controller, children, pongs } = setup();
+    await controller.start({ prompt: "work", cwd: "/repo", model: "p/m", thinking: "medium", capabilities: DEFAULT_CAPABILITIES });
+    children[0].emit({
+      type: "message_end",
+      message: { role: "assistant", stopReason: "aborted", errorMessage: "provider aborted" },
+    });
+    await settle(children[0]);
+    expect(pongs[0]).toMatchObject({
+      outcome: "failed",
+      sessionRef: "/sessions/1.jsonl",
+      error: "provider aborted",
+    });
   });
 
   it("reports a settled assistant error as failed", async () => {

--- a/extensions/subagents/controller.test.ts
+++ b/extensions/subagents/controller.test.ts
@@ -116,7 +116,7 @@ function setup(options: {
     createChild: async (spec) => {
       const child = new FakeChild(
         spec,
-        `/sessions/${children.length + 1}.jsonl`,
+        spec.session ?? `/sessions/${children.length + 1}.jsonl`,
         options.delayedPrompt,
         options.reportedCapabilities,
         options.delayedClose,
@@ -530,6 +530,43 @@ describe("SubagentController", () => {
       id: 1,
       outcome: "completed",
       finalText: "continued",
+    });
+    expect(pongs).toHaveLength(1);
+  });
+
+  it("classifies direct continuation cancellation during handshaking as interrupted", async () => {
+    const { controller, children, pongs } = setup({ delayedPrompt: true });
+    const starting = controller.start({
+      prompt: "one",
+      cwd: "/repo",
+      model: "p/m",
+      thinking: "low",
+      capabilities: DEFAULT_CAPABILITIES,
+    });
+    await vi.waitFor(() => expect(children).toHaveLength(1));
+    children[0].acceptPrompt();
+    await starting;
+    await settle(children[0]);
+    expect(pongs).toHaveLength(1);
+
+    const cancellation = new AbortController();
+    const continuing = controller.runContinuation({
+      id: 1,
+      prompt: "two",
+      model: "p/m",
+      thinking: "high",
+      capabilities: DEFAULT_CAPABILITIES,
+    }, cancellation.signal);
+    await vi.waitFor(() => expect(children).toHaveLength(2));
+
+    cancellation.abort();
+    children[1].emit({ type: "agent_settled" });
+    children[1].acceptPrompt();
+
+    await expect(continuing).resolves.toMatchObject({
+      id: 1,
+      outcome: "interrupted",
+      sessionRef: "/sessions/1.jsonl",
     });
     expect(pongs).toHaveLength(1);
   });

--- a/extensions/subagents/controller.ts
+++ b/extensions/subagents/controller.ts
@@ -3,6 +3,12 @@ import {
   cloneCapabilities,
   type CapabilitySnapshot,
 } from "./capabilities.ts";
+import {
+  ROOT_LINEAGE,
+  createChildLineage,
+  tightenLineage,
+  type ManagedLineage,
+} from "./lineage.ts";
 
 export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 export type TerminalOutcome = "completed" | "failed" | "interrupted";
@@ -13,6 +19,7 @@ export interface LaunchSpec {
   model: string;
   thinking: ThinkingLevel;
   capabilities: CapabilitySnapshot;
+  lineage: ManagedLineage;
   name?: string;
   session?: string;
 }
@@ -32,8 +39,10 @@ export interface RpcChild {
   close(): Promise<void>;
 }
 
-export interface StartInput extends LaunchSpec {
+export interface StartInput extends Omit<LaunchSpec, "lineage" | "session"> {
   prompt: string;
+  maxDepth?: number;
+  maxChildren?: number;
 }
 
 export interface ContinueInput {
@@ -42,6 +51,8 @@ export interface ContinueInput {
   model: string;
   thinking: ThinkingLevel;
   capabilities: CapabilitySnapshot;
+  maxDepth?: number;
+  maxChildren?: number;
 }
 
 export interface SubagentView {
@@ -60,7 +71,7 @@ export interface SubagentView {
   error?: string;
 }
 
-export interface Pong {
+export interface TerminalResult {
   id: number;
   name?: string;
   outcome: TerminalOutcome;
@@ -71,26 +82,28 @@ export interface Pong {
 
 interface RecordState extends SubagentView {
   capabilities: CapabilitySnapshot;
+  lineage: ManagedLineage;
   child?: RpcChild;
   accepted: boolean;
   finalizing: boolean;
-  ponged: boolean;
+  delivered: boolean;
   interruptRequested: boolean;
   pendingSettled: boolean;
   pendingExitError?: string;
   terminalError?: string;
-  directResolve?: (pong: Pong) => void;
+  assistantMessageEnded: boolean;
+  directResolve?: (result: TerminalResult) => void;
 }
 
 export interface ControllerOptions {
   createChild(spec: LaunchSpec): Promise<RpcChild>;
-  onPong(pong: Pong): void;
+  onPong(result: TerminalResult): void;
   onChange?(): void;
   handshakeMs?: number;
   now?: () => number;
+  lineage?: ManagedLineage;
 }
 
-const MAX_ACTIVE = 12;
 const DEFAULT_HANDSHAKE_MS = 10_000;
 
 function errorMessage(error: unknown): string {
@@ -110,8 +123,10 @@ export class SubagentController {
   private readonly options: Required<Pick<ControllerOptions, "handshakeMs" | "now">> & ControllerOptions;
   private nextId = 1;
   private shuttingDown = false;
+  private readonly lineage: ManagedLineage;
 
   constructor(options: ControllerOptions) {
+    this.lineage = options.lineage ?? ROOT_LINEAGE;
     this.options = {
       ...options,
       handshakeMs: options.handshakeMs ?? DEFAULT_HANDSHAKE_MS,
@@ -120,7 +135,7 @@ export class SubagentController {
   }
 
   list(): SubagentView[] {
-    return [...this.records.values()].map(({ capabilities, child: _child, accepted: _accepted, finalizing: _finalizing, ponged: _ponged, interruptRequested: _interruptRequested, pendingSettled: _pendingSettled, pendingExitError: _pendingExitError, terminalError: _terminalError, directResolve: _directResolve, ...view }) => ({
+    return [...this.records.values()].map(({ capabilities, lineage: _lineage, child: _child, accepted: _accepted, finalizing: _finalizing, delivered: _delivered, interruptRequested: _interruptRequested, pendingSettled: _pendingSettled, pendingExitError: _pendingExitError, terminalError: _terminalError, assistantMessageEnded: _assistantMessageEnded, directResolve: _directResolve, ...view }) => ({
       ...view,
       tools: capabilities.tools.map((tool) => tool.name),
     }));
@@ -138,10 +153,10 @@ export class SubagentController {
     }
   }
 
-  async run(input: StartInput, signal?: AbortSignal): Promise<Pong> {
+  async run(input: StartInput, signal?: AbortSignal): Promise<TerminalResult> {
     if (signal?.aborted) throw new Error("Subagent run was cancelled before launch.");
-    let resolveCompletion!: (pong: Pong) => void;
-    const completion = new Promise<Pong>((resolve) => {
+    let resolveCompletion!: (result: TerminalResult) => void;
+    const completion = new Promise<TerminalResult>((resolve) => {
       resolveCompletion = resolve;
     });
     const record = this.createStartRecord(input, resolveCompletion);
@@ -169,10 +184,10 @@ export class SubagentController {
     return this.continueWithDelivery(input);
   }
 
-  async runContinuation(input: ContinueInput, signal?: AbortSignal): Promise<Pong> {
+  async runContinuation(input: ContinueInput, signal?: AbortSignal): Promise<TerminalResult> {
     if (signal?.aborted) throw new Error("Subagent continuation was cancelled before launch.");
-    let resolveCompletion!: (pong: Pong) => void;
-    const completion = new Promise<Pong>((resolve) => {
+    let resolveCompletion!: (result: TerminalResult) => void;
+    const completion = new Promise<TerminalResult>((resolve) => {
       resolveCompletion = resolve;
     });
     await this.continueWithDelivery(input, resolveCompletion);
@@ -190,24 +205,27 @@ export class SubagentController {
 
   private async continueWithDelivery(
     input: ContinueInput,
-    directResolve?: (pong: Pong) => void,
+    directResolve?: (result: TerminalResult) => void,
   ): Promise<SubagentView> {
     this.assertCanLaunch();
     const record = this.requireRecord(input.id);
     if (record.active) throw new Error(`Subagent ${input.id} is already active; use steer instead.`);
     if (!record.sessionRef) throw new Error(`Subagent ${input.id} has no native session reference.`);
 
+    const lineage = tightenLineage(record.lineage, input);
     const previous = {
       state: record.state,
       error: record.error,
       model: record.model,
       thinking: record.thinking,
       capabilities: cloneCapabilities(record.capabilities),
+      lineage: record.lineage,
       directResolve: record.directResolve,
     };
     record.model = input.model;
     record.thinking = input.thinking;
     record.capabilities = cloneCapabilities(input.capabilities);
+    record.lineage = lineage;
     record.state = "handshaking";
     record.active = true;
     record.startedAt = this.options.now();
@@ -216,11 +234,12 @@ export class SubagentController {
     record.error = undefined;
     record.accepted = false;
     record.finalizing = false;
-    record.ponged = false;
+    record.delivered = false;
     record.interruptRequested = false;
     record.pendingSettled = false;
     record.pendingExitError = undefined;
     record.terminalError = undefined;
+    record.assistantMessageEnded = false;
     record.directResolve = directResolve;
     this.changed();
 
@@ -233,6 +252,7 @@ export class SubagentController {
       record.model = previous.model;
       record.thinking = previous.thinking;
       record.capabilities = previous.capabilities;
+      record.lineage = previous.lineage;
       record.directResolve = previous.directResolve;
       record.active = false;
       record.startedAt = undefined;
@@ -294,6 +314,7 @@ export class SubagentController {
       model: record.model,
       thinking: record.thinking,
       capabilities: cloneCapabilities(record.capabilities),
+      lineage: record.lineage,
       name: record.name,
       session: record.sessionRef,
     };
@@ -342,6 +363,7 @@ export class SubagentController {
       return;
     }
     if (event.type === "message_end" && event.message?.role === "assistant") {
+      record.assistantMessageEnded = true;
       record.terminalError = event.message.stopReason === "error" || event.message.stopReason === "aborted"
         ? event.message.errorMessage ?? `Assistant turn ended with ${event.message.stopReason}.`
         : undefined;
@@ -366,7 +388,7 @@ export class SubagentController {
   }
 
   private async finalize(record: RecordState, outcome: TerminalOutcome, error?: string, alreadyExited = false): Promise<void> {
-    if (record.finalizing || record.ponged || !record.accepted) return;
+    if (record.finalizing || record.delivered || !record.accepted) return;
     record.finalizing = true;
     record.state = "finalizing";
     record.error = error;
@@ -374,12 +396,14 @@ export class SubagentController {
 
     let finalText: string | undefined;
     if (!alreadyExited && record.child) {
-      try {
-        finalText = textData(await record.child.request({ type: "get_last_assistant_text" })).text ?? undefined;
-      } catch (requestError) {
-        if (outcome === "completed") {
-          outcome = "failed";
-          record.error = errorMessage(requestError);
+      if (record.assistantMessageEnded) {
+        try {
+          finalText = textData(await record.child.request({ type: "get_last_assistant_text" })).text ?? undefined;
+        } catch (requestError) {
+          if (outcome === "completed") {
+            outcome = "failed";
+            record.error = errorMessage(requestError);
+          }
         }
       }
       try {
@@ -401,9 +425,9 @@ export class SubagentController {
     record.error = record.error || undefined;
     this.changed();
 
-    if (this.shuttingDown || record.ponged || !record.sessionRef) return;
-    record.ponged = true;
-    const pong: Pong = {
+    if (this.shuttingDown || record.delivered || !record.sessionRef) return;
+    record.delivered = true;
+    const result: TerminalResult = {
       id: record.id,
       name: record.name,
       outcome,
@@ -413,12 +437,13 @@ export class SubagentController {
     };
     const directResolve = record.directResolve;
     record.directResolve = undefined;
-    if (directResolve) directResolve(pong);
-    else this.options.onPong(pong);
+    if (directResolve) directResolve(result);
+    else this.options.onPong(result);
   }
 
-  private createStartRecord(input: StartInput, directResolve?: (pong: Pong) => void): RecordState {
+  private createStartRecord(input: StartInput, directResolve?: (result: TerminalResult) => void): RecordState {
     this.assertCanLaunch();
+    const lineage = createChildLineage(this.lineage, input);
     const record: RecordState = {
       id: this.nextId++,
       name: input.name,
@@ -429,11 +454,13 @@ export class SubagentController {
       model: input.model,
       thinking: input.thinking,
       capabilities: cloneCapabilities(input.capabilities),
+      lineage,
       accepted: false,
       finalizing: false,
-      ponged: false,
+      delivered: false,
       interruptRequested: false,
       pendingSettled: false,
+      assistantMessageEnded: false,
       directResolve,
     };
     this.records.set(record.id, record);
@@ -443,8 +470,10 @@ export class SubagentController {
 
   private assertCanLaunch(): void {
     if (this.shuttingDown) throw new Error("The orchestrator session is shutting down.");
-    if ([...this.records.values()].filter((record) => record.active).length >= MAX_ACTIVE) {
-      throw new Error(`At most ${MAX_ACTIVE} subagents may be active; no work was queued.`);
+    if ([...this.records.values()].filter((record) => record.active).length >= this.lineage.maxChildren) {
+      throw new Error(
+        `At most ${this.lineage.maxChildren} direct subagents may be active; no child process was launched.`,
+      );
     }
   }
 

--- a/extensions/subagents/controller.ts
+++ b/extensions/subagents/controller.ts
@@ -190,13 +190,29 @@ export class SubagentController {
     const completion = new Promise<TerminalResult>((resolve) => {
       resolveCompletion = resolve;
     });
-    await this.continueWithDelivery(input, resolveCompletion);
+    let cancelled = false;
     const abort = () => {
-      if (this.records.get(input.id)?.active) void this.interrupt(input.id).catch(() => undefined);
+      cancelled = true;
+      const record = this.records.get(input.id);
+      if (!record?.active) return;
+      record.interruptRequested = true;
+      if (record.accepted && !record.finalizing && record.state !== "interrupting") {
+        void this.interrupt(input.id).catch(() => undefined);
+      }
     };
     signal?.addEventListener("abort", abort, { once: true });
     try {
-      if (signal?.aborted && this.records.get(input.id)?.active) await this.interrupt(input.id);
+      await this.continueWithDelivery(input, resolveCompletion, () => cancelled);
+      const record = this.records.get(input.id);
+      if (
+        cancelled
+        && record?.active
+        && record.accepted
+        && !record.finalizing
+        && record.state !== "interrupting"
+      ) {
+        await this.interrupt(input.id);
+      }
       return await completion;
     } finally {
       signal?.removeEventListener("abort", abort);
@@ -206,6 +222,7 @@ export class SubagentController {
   private async continueWithDelivery(
     input: ContinueInput,
     directResolve?: (result: TerminalResult) => void,
+    isCancelled?: () => boolean,
   ): Promise<SubagentView> {
     this.assertCanLaunch();
     const record = this.requireRecord(input.id);
@@ -235,7 +252,7 @@ export class SubagentController {
     record.accepted = false;
     record.finalizing = false;
     record.delivered = false;
-    record.interruptRequested = false;
+    record.interruptRequested = isCancelled?.() ?? false;
     record.pendingSettled = false;
     record.pendingExitError = undefined;
     record.terminalError = undefined;

--- a/extensions/subagents/index.ts
+++ b/extensions/subagents/index.ts
@@ -10,25 +10,40 @@ import { Type, type Static } from "typebox";
 import {
   SubagentController,
   type ContinueInput,
-  type Pong,
   type StartInput,
+  type TerminalResult,
   type SubagentView,
   type ThinkingLevel,
 } from "./controller.ts";
 import { buildChildInvocation, RpcSubprocess } from "./rpc-child.ts";
 import { captureCapabilities } from "./capabilities.ts";
 import { publishAsyncActivity } from "./async-activity.ts";
+import { readManagedLineage } from "./lineage.ts";
 
 const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
 const THINKING_LEVEL_SET = new Set<string>(THINKING_LEVELS);
-const PONG_TEXT_LIMIT = 8_000;
+const DELIVERY_MODES = ["async", "direct"] as const;
+const TERMINAL_TEXT_LIMIT = 8_000;
 
 const ReasoningSchema = StringEnum(THINKING_LEVELS, {
-  description: "Reasoning override for this dispatch; omit to inherit the orchestrator's current level",
+  description: "Reasoning override for this dispatch; omit to inherit the parent's current level",
+});
+const DeliverySchema = StringEnum(DELIVERY_MODES, {
+  description: "Delivery for this dispatch; async returns after acceptance and sends one later pong, while direct waits and returns the terminal result without a pong",
 });
 const ToolsSchema = Type.Array(Type.String({ minLength: 1, maxLength: 256 }), {
   maxItems: 256,
   description: "Optional restriction that keeps only these tools from the parent's active capability snapshot; omission inherits every active tool",
+});
+const MaxDepthSchema = Type.Integer({
+  minimum: 2,
+  maximum: 3,
+  description: "Optional maximum managed delegation depth for this child; may tighten but never raise the inherited ceiling",
+});
+const MaxChildrenSchema = Type.Integer({
+  minimum: 0,
+  maximum: 2,
+  description: "Optional direct active-child ceiling for this child; may tighten but never raise the inherited nested ceiling",
 });
 
 const StartSchema = Type.Object({
@@ -36,11 +51,14 @@ const StartSchema = Type.Object({
   name: Type.Optional(Type.String({ description: "Native Pi session display name" })),
   model: Type.Optional(Type.String({
     minLength: 1,
-    description: 'Explicit override in "<provider>/<model>" form, for example "openai-codex/gpt-5.6-luna"; omit to inherit the orchestrator\'s active model',
+    description: 'Explicit override in "<provider>/<model>" form, for example "openai-codex/gpt-5.6-luna"; omit to inherit the parent\'s active model',
   })),
   reasoning: Type.Optional(ReasoningSchema),
   cwd: Type.Optional(Type.String({ description: "Initial working directory; fixed for this conversation" })),
   tools: Type.Optional(ToolsSchema),
+  maxDepth: Type.Optional(MaxDepthSchema),
+  maxChildren: Type.Optional(MaxChildrenSchema),
+  delivery: Type.Optional(DeliverySchema),
 });
 
 const ContinueSchema = Type.Object({
@@ -48,10 +66,13 @@ const ContinueSchema = Type.Object({
   prompt: Type.String({ description: "Prompt for the next turn in the existing conversation" }),
   model: Type.Optional(Type.String({
     minLength: 1,
-    description: 'Explicit override in "<provider>/<model>" form, for example "openai-codex/gpt-5.6-luna"; omit to inherit the orchestrator\'s active model',
+    description: 'Explicit override in "<provider>/<model>" form, for example "openai-codex/gpt-5.6-luna"; omit to inherit the parent\'s active model',
   })),
   reasoning: Type.Optional(ReasoningSchema),
   tools: Type.Optional(ToolsSchema),
+  maxDepth: Type.Optional(MaxDepthSchema),
+  maxChildren: Type.Optional(MaxChildrenSchema),
+  delivery: Type.Optional(DeliverySchema),
 });
 
 const SteerSchema = Type.Object({
@@ -66,7 +87,7 @@ type StartParams = Static<typeof StartSchema>;
 type ContinueParams = Static<typeof ContinueSchema>;
 
 function activeModel(ctx: ExtensionContext): string {
-  if (!ctx.model) throw new Error("The orchestrator has no active model to inherit.");
+  if (!ctx.model) throw new Error("The parent has no active model to inherit.");
   return `${ctx.model.provider}/${ctx.model.id}`;
 }
 
@@ -112,10 +133,10 @@ function parseIdMessage(args: string, usage: string): { id: number; message: str
   return { id: Number(match[1]), message: match[2].trim() };
 }
 
-function boundedPongText(pong: Pong): { text?: string; truncated: boolean } {
+function boundedTerminalText(pong: TerminalResult): { text?: string; truncated: boolean } {
   if (!pong.finalText) return { truncated: false };
-  if (pong.finalText.length <= PONG_TEXT_LIMIT) return { text: pong.finalText, truncated: false };
-  return { text: pong.finalText.slice(0, PONG_TEXT_LIMIT), truncated: true };
+  if (pong.finalText.length <= TERMINAL_TEXT_LIMIT) return { text: pong.finalText, truncated: false };
+  return { text: pong.finalText.slice(0, TERMINAL_TEXT_LIMIT), truncated: true };
 }
 
 export function buildActiveUi(views: SubagentView[], now: number): { lines?: string[]; status?: string } {
@@ -132,9 +153,11 @@ export function buildActiveUi(views: SubagentView[], now: number): { lines?: str
   return { lines, status: `subagents: ${active.length}` };
 }
 
-export function buildPongMessage(pong: Pong): { content: string; details: Pong & { finalText?: string; truncated: boolean } } {
-  const final = boundedPongText(pong);
-  const heading = `[PONG subagent #${pong.id}${pong.name ? ` ${pong.name}` : ""}] ${pong.outcome}`;
+function buildTerminalMessage(
+  pong: TerminalResult,
+  heading: string,
+): { content: string; details: TerminalResult & { finalText?: string; truncated: boolean } } {
+  const final = boundedTerminalText(pong);
   const parts = [heading, `Session: ${pong.sessionRef}`];
   if (pong.error) parts.push(`Error: ${pong.error}`);
   if (final.text) parts.push(`Final assistant message${final.truncated ? " (truncated to 8,000 characters)" : ""}:\n${final.text}`);
@@ -144,9 +167,25 @@ export function buildPongMessage(pong: Pong): { content: string; details: Pong &
   };
 }
 
+export function buildPongMessage(pong: TerminalResult): ReturnType<typeof buildTerminalMessage> {
+  return buildTerminalMessage(
+    pong,
+    `[PONG subagent #${pong.id}${pong.name ? ` ${pong.name}` : ""}] ${pong.outcome}`,
+  );
+}
+
+export function buildDirectResult(pong: TerminalResult): ReturnType<typeof buildTerminalMessage> {
+  return buildTerminalMessage(
+    pong,
+    `[SUBAGENT #${pong.id}${pong.name ? ` ${pong.name}` : ""}] ${pong.outcome}`,
+  );
+}
+
 export default function subagentsExtension(pi: ExtensionAPI) {
+  const lineage = readManagedLineage();
+
   pi.registerMessageRenderer("subagent-pong", (message, { expanded }, theme) => {
-    const details = message.details as (Pong & { truncated?: boolean }) | undefined;
+    const details = message.details as (TerminalResult & { truncated?: boolean }) | undefined;
     const heading = details
       ? `[PONG subagent #${details.id}${details.name ? ` ${details.name}` : ""}] ${details.outcome}`
       : "[PONG subagent]";
@@ -192,7 +231,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
     }
   };
 
-  const sendPong = (pong: Pong) => {
+  const sendPong = (pong: TerminalResult) => {
     const message = buildPongMessage(pong);
     pi.sendMessage(
       {
@@ -206,6 +245,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
   };
 
   controller = new SubagentController({
+    lineage,
     createChild: async (spec) => new RpcSubprocess(buildChildInvocation(spec)),
     onPong: sendPong,
     onChange: refreshUi,
@@ -218,6 +258,8 @@ export default function subagentsExtension(pi: ExtensionAPI) {
     thinking: selectedThinking(params.reasoning, pi.getThinkingLevel() as ThinkingLevel),
     cwd: resolve(ctx.cwd, params.cwd ?? "."),
     capabilities: captureCapabilities(pi, params.tools),
+    maxDepth: params.maxDepth,
+    maxChildren: params.maxChildren,
   });
 
   const start = (params: StartParams, ctx: ExtensionContext): Promise<SubagentView> => {
@@ -230,6 +272,8 @@ export default function subagentsExtension(pi: ExtensionAPI) {
     model: selectedModel(params.model, ctx),
     thinking: selectedThinking(params.reasoning, pi.getThinkingLevel() as ThinkingLevel),
     capabilities: captureCapabilities(pi, params.tools),
+    maxDepth: params.maxDepth,
+    maxChildren: params.maxChildren,
   });
 
   const continueSubagent = (params: ContinueParams, ctx: ExtensionContext): Promise<SubagentView> => {
@@ -239,20 +283,21 @@ export default function subagentsExtension(pi: ExtensionAPI) {
   pi.registerTool({
     name: "subagent_start",
     label: "Start Subagent",
-    description: 'Start a clean persistent Pi conversation with the parent\'s active tools and required extension providers. Omit tools to inherit the complete active snapshot; an explicit list can only narrow it. Normal skills and repository instructions are discovered for the child cwd. In print mode, the tool waits for terminal completion and returns the bounded final result directly. In other modes, it returns after RPC prompt acceptance and completion arrives later as one pong. Optional model or reasoning overrides apply only for an explicit user request; model overrides require "<provider>/<model>".',
+    description: 'Start a clean persistent Pi conversation with the parent\'s active tools and required extension providers. Omit tools to inherit the complete active snapshot; an explicit list can only narrow it. Normal skills and repository instructions are discovered for the child cwd. Async delivery is the default outside print mode: it returns after acceptance and sends one later pong. Select direct delivery explicitly to keep the tool call pending and return one bounded terminal result without a pong. Print mode is always direct. Optional model or reasoning overrides apply only for an explicit user request; model overrides require "<provider>/<model>".',
     promptSnippet: "Start an independent Pi conversation with a complete prompt",
     promptGuidelines: [
-      "Set each subagent_start model or reasoning override only when the user explicitly requests that value for this dispatch; explicit model overrides must use the qualified <provider>/<model> form. Omit every unrequested override so it inherits the orchestrator's active value.",
-      "Only after deciding to call subagent_start, inspect PI_PROVIDER, PI_MODEL, and PI_REASONING_LEVEL to identify the orchestrator's active route immediately before dispatch. Do not inspect routing on ordinary turns or merely because this tool is available. Unless the user explicitly requests routing, omit model and reasoning overrides so the dispatch inherits that active route rather than forcing a global or preferred default.",
+      "Set each subagent_start model or reasoning override only when the user explicitly requests that value for this dispatch; explicit model overrides must use the qualified <provider>/<model> form. Omit every unrequested override so it inherits the parent's active value.",
+      "Only after deciding to call subagent_start, inspect PI_PROVIDER, PI_MODEL, and PI_REASONING_LEVEL to identify the parent's active route immediately before dispatch. Do not inspect routing on ordinary turns or merely because this tool is available. Unless the user explicitly requests routing, omit model and reasoning overrides so the dispatch inherits that active route rather than forcing a global or preferred default.",
       "When multiple independent delegations are useful, issue their subagent_start calls in the same turn so Pi can run them concurrently; outside print mode, do not wait for one pong before starting another.",
+      "Use subagent_start delivery=direct only for dependent work that must consume the bounded terminal result in the current turn; role, name, and delegation depth never select direct delivery implicitly.",
       "In print mode, subagent_start returns only after the subagent reaches a terminal outcome; inspect that direct result before continuing dependent work.",
-      "Outside print mode, after subagent_start accepts a prompt, never wait, sleep, or poll for its result. Continue only useful independent work or end the response so user input and the later pong can be delivered.",
+      "Outside print mode, after an asynchronous subagent_start accepts a prompt, never wait, sleep, or poll for its result. Continue only useful independent work or end the response so user input and the later pong can be delivered.",
     ],
     parameters: StartSchema,
     async execute(_id, params, signal, _onUpdate, ctx) {
-      if (ctx.mode === "print") {
+      if (ctx.mode === "print" || params.delivery === "direct") {
         const pong = await controller.run(startInput(params, ctx), signal);
-        const message = buildPongMessage(pong);
+        const message = buildDirectResult(pong);
         return {
           content: [{ type: "text", text: message.content }],
           details: message.details,
@@ -273,18 +318,19 @@ export default function subagentsExtension(pi: ExtensionAPI) {
   pi.registerTool({
     name: "subagent_continue",
     label: "Continue Subagent",
-    description: 'Start another turn in a settled known subagent conversation with a fresh snapshot of the parent\'s active tools and required extension providers. Omit tools to inherit the complete active snapshot; an explicit list can only narrow it. In print mode, the tool waits for terminal completion and returns the bounded final result directly. In other modes, it returns after prompt acceptance and completion arrives later as one pong. Optional model or reasoning overrides apply only for an explicit user request; model overrides require "<provider>/<model>".',
+    description: 'Start another turn in a settled known subagent conversation with a fresh snapshot of the parent\'s active tools and required extension providers. Omit tools to inherit the complete active snapshot; an explicit list can only narrow it. Async delivery is the default outside print mode: it returns after acceptance and sends one later pong. Select direct delivery explicitly to keep the tool call pending and return one bounded terminal result without a pong. Print mode is always direct. Optional model or reasoning overrides apply only for an explicit user request; model overrides require "<provider>/<model>".',
     promptGuidelines: [
-      "Set each subagent_continue model or reasoning override only when the user explicitly requests that value for this dispatch; explicit model overrides must use the qualified <provider>/<model> form. Omit every unrequested override so it inherits the orchestrator's active value.",
-      "Only after deciding to call subagent_continue, inspect PI_PROVIDER, PI_MODEL, and PI_REASONING_LEVEL to identify the orchestrator's active route immediately before dispatch. Do not inspect routing on ordinary turns or merely because this tool is available. Unless the user explicitly requests routing, omit model and reasoning overrides so the dispatch inherits that active route rather than forcing a global or preferred default.",
+      "Set each subagent_continue model or reasoning override only when the user explicitly requests that value for this dispatch; explicit model overrides must use the qualified <provider>/<model> form. Omit every unrequested override so it inherits the parent's active value.",
+      "Only after deciding to call subagent_continue, inspect PI_PROVIDER, PI_MODEL, and PI_REASONING_LEVEL to identify the parent's active route immediately before dispatch. Do not inspect routing on ordinary turns or merely because this tool is available. Unless the user explicitly requests routing, omit model and reasoning overrides so the dispatch inherits that active route rather than forcing a global or preferred default.",
+      "Use subagent_continue delivery=direct only for dependent work that must consume the bounded terminal result in the current turn; role, name, and delegation depth never select direct delivery implicitly.",
       "In print mode, subagent_continue returns only after the continuation reaches a terminal outcome; inspect that direct result before continuing dependent work.",
-      "Outside print mode, after subagent_continue accepts a prompt, never wait, sleep, or poll for its result. Continue only useful independent work or end the response so user input and the later pong can be delivered.",
+      "Outside print mode, after an asynchronous subagent_continue accepts a prompt, never wait, sleep, or poll for its result. Continue only useful independent work or end the response so user input and the later pong can be delivered.",
     ],
     parameters: ContinueSchema,
     async execute(_id, params, signal, _onUpdate, ctx) {
-      if (ctx.mode === "print") {
+      if (ctx.mode === "print" || params.delivery === "direct") {
         const pong = await controller.runContinuation(continuationInput(params, ctx), signal);
-        const message = buildPongMessage(pong);
+        const message = buildDirectResult(pong);
         return {
           content: [{ type: "text", text: message.content }],
           details: message.details,
@@ -327,14 +373,14 @@ export default function subagentsExtension(pi: ExtensionAPI) {
   pi.registerTool({
     name: "subagent_list",
     label: "List Subagents",
-    description: "Take one snapshot of conversations known to this orchestrator session. This is not a completion wait or polling mechanism.",
+    description: "Take one snapshot of direct subagent conversations known to this parent session. This is not a completion wait or polling mechanism.",
     promptGuidelines: [
       "Use subagent_list only for a status snapshot needed for a user request or an orchestration decision; never call it repeatedly to poll for completion.",
     ],
     parameters: ListSchema,
     async execute() {
       const views = controller.list();
-      const text = views.length ? views.map(formatView).join("\n") : "No subagents are known in this orchestrator session.";
+      const text = views.length ? views.map(formatView).join("\n") : "No subagents are known in this parent session.";
       return { content: [{ type: "text", text }], details: { subagents: views } };
     },
   });
@@ -346,8 +392,13 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         const object = parseObject<StartParams>(args);
         const params = object ?? { prompt: args.trim() };
         if (!params.prompt) throw new Error("Usage: /sub <prompt> or /sub {\"prompt\": \"...\"}");
-        const view = await start(params, ctx);
-        ctx.ui.notify(`Subagent #${view.id} started.`, "info");
+        if (params.delivery === "direct") {
+          const result = await controller.run(startInput(params, ctx));
+          ctx.ui.notify(buildDirectResult(result).content, "info");
+        } else {
+          const view = await start(params, ctx);
+          ctx.ui.notify(`Subagent #${view.id} started.`, "info");
+        }
       } catch (error) {
         ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
       }
@@ -359,12 +410,17 @@ export default function subagentsExtension(pi: ExtensionAPI) {
     handler: async (args, ctx) => {
       try {
         const object = parseObject<ContinueParams>(args);
-        const params = object ?? (() => {
+        const params: ContinueParams = object ?? (() => {
           const parsed = parseIdMessage(args, "Usage: /subcont <id> <prompt>");
           return { id: parsed.id, prompt: parsed.message };
         })();
-        const view = await continueSubagent(params, ctx);
-        ctx.ui.notify(`Subagent #${view.id} continued.`, "info");
+        if (params.delivery === "direct") {
+          const result = await controller.runContinuation(continuationInput(params, ctx));
+          ctx.ui.notify(buildDirectResult(result).content, "info");
+        } else {
+          const view = await continueSubagent(params, ctx);
+          ctx.ui.notify(`Subagent #${view.id} continued.`, "info");
+        }
       } catch (error) {
         ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
       }
@@ -399,7 +455,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
   });
 
   pi.registerCommand("sublist", {
-    description: "List subagents known to this orchestrator session",
+    description: "List direct subagents known to this parent session",
     handler: async (_args, ctx) => {
       const views = controller.list();
       ctx.ui.notify(views.length ? views.map(formatView).join("\n") : "No known subagents.", "info");

--- a/extensions/subagents/inheritance.test.ts
+++ b/extensions/subagents/inheritance.test.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const rpc = vi.hoisted(() => ({
-  invocations: [] as Array<{ args: string[] }>,
+  invocations: [] as Array<{ args: string[]; env?: NodeJS.ProcessEnv }>,
   capabilityReports: [] as Array<{
     tools: Array<{ name: string; provider: string }>;
     extensionPaths: string[];
@@ -10,7 +10,7 @@ const rpc = vi.hoisted(() => ({
   children: [] as Array<{
     closed: boolean;
     requests: Array<Record<string, unknown>>;
-    emit(event: { type: string }): void;
+    emit(event: { type: string; message?: { role?: string; stopReason?: string } }): void;
   }>,
 }));
 
@@ -21,15 +21,15 @@ vi.mock("./rpc-child.ts", async (importOriginal) => {
     RpcSubprocess: class {
       closed = false;
       requests: Array<Record<string, unknown>> = [];
-      private listeners: Array<(event: { type: string }) => void> = [];
+      private listeners: Array<(event: { type: string; message?: { role?: string; stopReason?: string } }) => void> = [];
       private readonly sessionFile: string;
       private readonly capabilities: {
         tools: Array<{ name: string; provider: string }>;
         extensionPaths: string[];
       };
 
-      constructor(invocation: { args: string[] }) {
-        rpc.invocations.push({ args: invocation.args });
+      constructor(invocation: { args: string[]; env?: NodeJS.ProcessEnv }) {
+        rpc.invocations.push({ args: invocation.args, env: invocation.env });
         const sessionIndex = invocation.args.indexOf("--session");
         this.sessionFile = sessionIndex >= 0
           ? invocation.args[sessionIndex + 1]
@@ -54,7 +54,7 @@ vi.mock("./rpc-child.ts", async (importOriginal) => {
         return this.capabilities;
       }
 
-      onEvent(listener: (event: { type: string }) => void): () => void {
+      onEvent(listener: (event: { type: string; message?: { role?: string; stopReason?: string } }) => void): () => void {
         this.listeners.push(listener);
         return () => undefined;
       }
@@ -63,7 +63,7 @@ vi.mock("./rpc-child.ts", async (importOriginal) => {
         return () => undefined;
       }
 
-      emit(event: { type: string }): void {
+      emit(event: { type: string; message?: { role?: string; stopReason?: string } }): void {
         for (const listener of this.listeners) listener(event);
       }
 
@@ -139,15 +139,60 @@ function setup() {
 }
 
 async function settle(index: number): Promise<void> {
+  rpc.children[index].emit({
+    type: "message_end",
+    message: { role: "assistant", stopReason: "stop" },
+  });
   rpc.children[index].emit({ type: "agent_settled" });
   await vi.waitFor(() => expect(rpc.children[index].closed).toBe(true));
 }
 
 describe("subagent routing inheritance", () => {
   beforeEach(() => {
+    delete process.env.OMPI_SUBAGENT_LINEAGE;
     rpc.invocations.length = 0;
     rpc.capabilityReports.length = 0;
     rpc.children.length = 0;
+  });
+
+  it("keeps delegation visible at maximum depth and rejects before launch", async () => {
+    process.env.OMPI_SUBAGENT_LINEAGE = JSON.stringify({
+      version: 1,
+      depth: 3,
+      maxDepth: 3,
+      maxChildren: 2,
+    });
+    const { tools, ctx } = setup();
+
+    expect(tools.has("subagent_start")).toBe(true);
+    expect(process.env.OMPI_SUBAGENT_LINEAGE).toBeUndefined();
+    await expect(tools.get("subagent_start").execute(
+      "start",
+      { prompt: "too deep" },
+      undefined,
+      undefined,
+      ctx,
+    )).rejects.toThrow("maximum delegation depth 3");
+    expect(rpc.invocations).toEqual([]);
+  });
+
+  it("lets a nested parent opt out with a zero direct-child ceiling", async () => {
+    process.env.OMPI_SUBAGENT_LINEAGE = JSON.stringify({
+      version: 1,
+      depth: 2,
+      maxDepth: 3,
+      maxChildren: 0,
+    });
+    const { tools, ctx } = setup();
+
+    await expect(tools.get("subagent_start").execute(
+      "start",
+      { prompt: "not launched" },
+      undefined,
+      undefined,
+      ctx,
+    )).rejects.toThrow("At most 0 direct subagents");
+    expect(rpc.invocations).toEqual([]);
   });
 
   it("publishes active turns for session-level status integrations", async () => {
@@ -353,11 +398,138 @@ describe("subagent routing inheritance", () => {
       expect(tool.promptGuidelines.join(" ")).toContain("only when the user explicitly requests");
       expect(tool.promptGuidelines.join(" ")).toContain("qualified <provider>/<model> form");
       expect(tool.promptGuidelines.join(" ")).toContain("Omit every unrequested override");
-      expect(tool.promptGuidelines.join(" ")).toContain("orchestrator's active route");
+      expect(tool.promptGuidelines.join(" ")).toContain("parent's active route");
       expect(tool.promptGuidelines.join(" ")).not.toContain("openai-codex/gpt-5.6-sol");
       expect(tool.promptGuidelines.join(" ")).toContain("PI_PROVIDER, PI_MODEL, and PI_REASONING_LEVEL");
       expect(tool.promptGuidelines.join(" ")).toContain("Do not inspect routing on ordinary turns");
     }
+  });
+
+  it("exposes monotonic child ceilings and passes tightened values mechanically", async () => {
+    const { tools, ctx } = setup();
+    const start = tools.get("subagent_start");
+    const continuation = tools.get("subagent_continue");
+
+    for (const tool of [start, continuation]) {
+      expect(tool.parameters.properties.maxDepth).toMatchObject({ minimum: 2, maximum: 3 });
+      expect(tool.parameters.properties.maxChildren).toMatchObject({ minimum: 0, maximum: 2 });
+    }
+
+    await start.execute("start", {
+      prompt: "one",
+      maxDepth: 2,
+      maxChildren: 0,
+    }, undefined, undefined, ctx);
+    expect(JSON.parse(rpc.invocations[0].env?.OMPI_SUBAGENT_LINEAGE ?? "")).toEqual({
+      version: 1,
+      depth: 2,
+      maxDepth: 2,
+      maxChildren: 0,
+    });
+    await settle(0);
+
+    await expect(continuation.execute("continue", {
+      id: 1,
+      prompt: "raise",
+      maxDepth: 3,
+    }, undefined, undefined, ctx)).rejects.toThrow("cannot raise");
+    expect(rpc.invocations).toHaveLength(1);
+  });
+
+  it("returns an explicitly direct start outside print mode exactly once without a later pong", async () => {
+    const { tools, ctx, messages } = setup();
+    (ctx as any).mode = "tui";
+    const start = tools.get("subagent_start");
+    expect(start.parameters.properties.delivery.enum).toEqual(["async", "direct"]);
+    let completed = false;
+
+    const running = start.execute(
+      "start",
+      { prompt: "one", delivery: "direct" },
+      undefined,
+      undefined,
+      ctx,
+    ).then((result: unknown) => {
+      completed = true;
+      return result;
+    });
+
+    await vi.waitFor(() => expect(rpc.children).toHaveLength(1));
+    expect(completed).toBe(false);
+    await settle(0);
+    rpc.children[0].emit({ type: "agent_settled" });
+
+    await expect(running).resolves.toMatchObject({
+      content: [{ type: "text", text: expect.stringContaining("done") }],
+      details: {
+        id: 1,
+        outcome: "completed",
+        sessionRef: "/sessions/1.jsonl",
+        finalText: "done",
+      },
+    });
+    expect(messages).toEqual([]);
+  });
+
+  it("returns an explicitly direct continuation outside print mode without another pong", async () => {
+    const { tools, ctx, messages } = setup();
+    (ctx as any).mode = "tui";
+    await tools.get("subagent_start").execute(
+      "start",
+      { prompt: "one" },
+      undefined,
+      undefined,
+      ctx,
+    );
+    await settle(0);
+    expect(messages).toHaveLength(1);
+
+    const continuing = tools.get("subagent_continue").execute(
+      "continue",
+      { id: 1, prompt: "two", delivery: "direct" },
+      undefined,
+      undefined,
+      ctx,
+    );
+    await vi.waitFor(() => expect(rpc.children).toHaveLength(2));
+    await settle(1);
+
+    await expect(continuing).resolves.toMatchObject({
+      details: {
+        id: 1,
+        outcome: "completed",
+        sessionRef: "/sessions/1.jsonl",
+      },
+    });
+    expect(messages).toHaveLength(1);
+  });
+
+  it("keeps independently issued direct siblings concurrent", async () => {
+    const { tools, ctx, messages } = setup();
+    (ctx as any).mode = "tui";
+    const start = tools.get("subagent_start");
+    let completed = 0;
+    const first = start.execute("one", {
+      prompt: "one",
+      delivery: "direct",
+    }, undefined, undefined, ctx).then((result: unknown) => {
+      completed += 1;
+      return result;
+    });
+    const second = start.execute("two", {
+      prompt: "two",
+      delivery: "direct",
+    }, undefined, undefined, ctx).then((result: unknown) => {
+      completed += 1;
+      return result;
+    });
+
+    await vi.waitFor(() => expect(rpc.children).toHaveLength(2));
+    expect(completed).toBe(0);
+    await Promise.all([settle(0), settle(1)]);
+    await expect(Promise.all([first, second])).resolves.toHaveLength(2);
+    expect(completed).toBe(2);
+    expect(messages).toEqual([]);
   });
 
   it("returns the terminal subagent result directly in print mode without a pong follow-up", async () => {
@@ -497,6 +669,23 @@ describe("subagent routing inheritance", () => {
     }, undefined, undefined, ctx);
     expect(valueAfter(rpc.invocations[1].args, "--model")).toBe("provider/second");
     expect(valueAfter(rpc.invocations[1].args, "--thinking")).toBe("high");
+  });
+
+  it("honors explicit direct delivery in JSON slash commands without a pong", async () => {
+    const { commands, ctx, messages, notifications } = setup();
+    const starting = commands.get("sub").handler(
+      '{"prompt":"one","delivery":"direct"}',
+      ctx,
+    );
+    await vi.waitFor(() => expect(rpc.children).toHaveLength(1));
+    expect(notifications).toEqual([]);
+    await settle(0);
+    await starting;
+
+    expect(messages).toEqual([]);
+    expect(notifications).toEqual([
+      expect.stringContaining("[SUBAGENT #1] completed"),
+    ]);
   });
 
   it("applies JSON slash-command overrides independently per dispatch", async () => {

--- a/extensions/subagents/lineage.ts
+++ b/extensions/subagents/lineage.ts
@@ -1,0 +1,148 @@
+export interface ManagedLineage {
+  readonly depth: number;
+  readonly maxDepth: number;
+  readonly maxChildren: number;
+}
+
+export const ROOT_LINEAGE: ManagedLineage = {
+  depth: 1,
+  maxDepth: 3,
+  maxChildren: 12,
+};
+
+export const MANAGED_LINEAGE_ENV = "OMPI_SUBAGENT_LINEAGE";
+
+const DEFAULT_NESTED_MAX_CHILDREN = 2;
+
+export interface ChildCeilingInput {
+  readonly maxDepth?: number;
+  readonly maxChildren?: number;
+}
+
+function boundedInteger(value: number, label: string, minimum: number, maximum: number): number {
+  if (!Number.isInteger(value) || value < minimum || value > maximum) {
+    throw new Error(`${label} must be an integer from ${minimum} through ${maximum}.`);
+  }
+  return value;
+}
+
+function validateLineage(value: ManagedLineage): ManagedLineage {
+  const depth = boundedInteger(value.depth, "Delegation depth", 1, ROOT_LINEAGE.maxDepth);
+  const maxDepth = boundedInteger(
+    value.maxDepth,
+    "Maximum delegation depth",
+    depth,
+    ROOT_LINEAGE.maxDepth,
+  );
+  const localMaximum = depth === ROOT_LINEAGE.depth
+    ? ROOT_LINEAGE.maxChildren
+    : DEFAULT_NESTED_MAX_CHILDREN;
+  const maxChildren = boundedInteger(
+    value.maxChildren,
+    "Direct active-child ceiling",
+    0,
+    localMaximum,
+  );
+  return { depth, maxDepth, maxChildren };
+}
+
+export function encodeManagedLineage(lineage: ManagedLineage): string {
+  const valid = validateLineage(lineage);
+  return JSON.stringify({ version: 1, ...valid });
+}
+
+export function readManagedLineage(
+  environment: NodeJS.ProcessEnv = process.env,
+): ManagedLineage {
+  const encoded = environment[MANAGED_LINEAGE_ENV];
+  delete environment[MANAGED_LINEAGE_ENV];
+  if (encoded === undefined) return ROOT_LINEAGE;
+  if (encoded.length === 0 || encoded.length > 256) {
+    throw new Error("Managed subagent lineage metadata is invalid.");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(encoded);
+  } catch (error) {
+    throw new Error("Managed subagent lineage metadata is not valid JSON.", { cause: error });
+  }
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("Managed subagent lineage metadata is invalid.");
+  }
+  const candidate = parsed as Partial<ManagedLineage> & { version?: unknown };
+  if (
+    candidate.version !== 1
+    || typeof candidate.depth !== "number"
+    || typeof candidate.maxDepth !== "number"
+    || typeof candidate.maxChildren !== "number"
+  ) {
+    throw new Error("Managed subagent lineage metadata is invalid.");
+  }
+  return validateLineage({
+    depth: candidate.depth,
+    maxDepth: candidate.maxDepth,
+    maxChildren: candidate.maxChildren,
+  });
+}
+
+export function createChildLineage(
+  parent: ManagedLineage,
+  requested: ChildCeilingInput = {},
+): ManagedLineage {
+  if (parent.depth >= parent.maxDepth) {
+    throw new Error(
+      `Subagent is at maximum delegation depth ${parent.maxDepth}; no child process was launched.`,
+    );
+  }
+  const depth = parent.depth + 1;
+  const inheritedMaxChildren = Math.min(DEFAULT_NESTED_MAX_CHILDREN, parent.maxChildren);
+  return {
+    depth,
+    maxDepth: requested.maxDepth === undefined
+      ? parent.maxDepth
+      : boundedInteger(requested.maxDepth, "Child maximum depth", depth, parent.maxDepth),
+    maxChildren: requested.maxChildren === undefined
+      ? inheritedMaxChildren
+      : boundedInteger(
+        requested.maxChildren,
+        "Child direct active-child ceiling",
+        0,
+        inheritedMaxChildren,
+      ),
+  };
+}
+
+export function tightenLineage(
+  current: ManagedLineage,
+  requested: ChildCeilingInput,
+): ManagedLineage {
+  if (requested.maxDepth !== undefined && requested.maxDepth > current.maxDepth) {
+    throw new Error(
+      `Continuation cannot raise maximum delegation depth above ${current.maxDepth}.`,
+    );
+  }
+  if (requested.maxChildren !== undefined && requested.maxChildren > current.maxChildren) {
+    throw new Error(
+      `Continuation cannot raise the direct active-child ceiling above ${current.maxChildren}.`,
+    );
+  }
+  return {
+    depth: current.depth,
+    maxDepth: requested.maxDepth === undefined
+      ? current.maxDepth
+      : boundedInteger(
+        requested.maxDepth,
+        "Continuation maximum depth",
+        current.depth,
+        current.maxDepth,
+      ),
+    maxChildren: requested.maxChildren === undefined
+      ? current.maxChildren
+      : boundedInteger(
+        requested.maxChildren,
+        "Continuation direct active-child ceiling",
+        0,
+        current.maxChildren,
+      ),
+  };
+}

--- a/extensions/subagents/native-nesting.test.ts
+++ b/extensions/subagents/native-nesting.test.ts
@@ -1,0 +1,367 @@
+import { mkdtemp, mkdir, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CapabilitySnapshot } from "./capabilities.ts";
+import { SubagentController } from "./controller.ts";
+import { buildChildInvocation, RpcSubprocess } from "./rpc-child.ts";
+
+const PI_CLI = resolve("node_modules/@earendil-works/pi-coding-agent/dist/cli.js");
+const SUBAGENT_EXTENSION = resolve("extensions/subagents/index.ts");
+const temporaryRoots: string[] = [];
+
+const NESTED_PROVIDER_EXTENSION = String.raw`
+import { appendFileSync } from "node:fs";
+import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+
+function usage() {
+  return {
+    input: 1,
+    output: 1,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 2,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+}
+
+function lastUserText(messages) {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message.role !== "user") continue;
+    if (typeof message.content === "string") return message.content;
+    return message.content
+      .filter((item) => item.type === "text")
+      .map((item) => item.text)
+      .join("");
+  }
+  return "";
+}
+
+function textStream(model, text) {
+  const stream = createAssistantMessageEventStream();
+  const partial = {
+    role: "assistant",
+    content: [],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: usage(),
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+  const message = { ...partial, content: [{ type: "text", text }] };
+  queueMicrotask(() => {
+    stream.push({ type: "start", partial });
+    stream.push({ type: "text_start", contentIndex: 0, partial });
+    stream.push({ type: "text_delta", contentIndex: 0, delta: text, partial: message });
+    stream.push({ type: "text_end", contentIndex: 0, content: text, partial: message });
+    stream.push({ type: "done", reason: "stop", message });
+    stream.end(message);
+  });
+  return stream;
+}
+
+function toolStream(model, prompt) {
+  const stream = createAssistantMessageEventStream();
+  const partial = {
+    role: "assistant",
+    content: [],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: usage(),
+    stopReason: "toolUse",
+    timestamp: Date.now(),
+  };
+  const toolCall = {
+    type: "toolCall",
+    id: "call_leaf",
+    name: "subagent_start",
+    arguments: { prompt, delivery: "direct" },
+  };
+  const message = { ...partial, content: [toolCall] };
+  queueMicrotask(() => {
+    stream.push({ type: "start", partial });
+    stream.push({ type: "toolcall_start", contentIndex: 0, partial: message });
+    stream.push({ type: "toolcall_end", contentIndex: 0, toolCall, partial: message });
+    stream.push({ type: "done", reason: "toolUse", message });
+    stream.end(message);
+  });
+  return stream;
+}
+
+function hangingStream(model, signal) {
+  const stream = createAssistantMessageEventStream();
+  const partial = {
+    role: "assistant",
+    content: [],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: usage(),
+    stopReason: "pending",
+    timestamp: Date.now(),
+  };
+  queueMicrotask(() => stream.push({ type: "start", partial }));
+  const abort = () => {
+    const error = {
+      ...partial,
+      stopReason: "aborted",
+      errorMessage: "fixture leaf interrupted",
+    };
+    stream.push({ type: "error", reason: "aborted", error });
+    stream.end();
+  };
+  if (signal?.aborted) queueMicrotask(abort);
+  else signal?.addEventListener("abort", abort, { once: true });
+  return stream;
+}
+
+function streamFixture(model, context, options) {
+  const userText = lastUserText(context.messages);
+  const toolResult = context.messages.findLast((message) =>
+    message.role === "toolResult" && message.toolName === "subagent_start"
+  );
+  const phase = userText === "LEAF"
+    ? "leaf"
+    : userText === "HANG"
+      ? "leaf-hang"
+      : toolResult
+        ? "coordinator-after"
+        : "coordinator-before";
+  appendFileSync(process.env.OMPI_NESTED_CAPTURE, JSON.stringify({
+    phase,
+    pid: process.pid,
+    toolResult: toolResult?.content,
+  }) + "\n");
+  if (phase === "coordinator-before") {
+    return toolStream(
+      model,
+      userText === "SHUTDOWN" || userText === "CANCEL" ? "HANG" : "LEAF",
+    );
+  }
+  if (phase === "leaf") return textStream(model, "leaf done");
+  if (phase === "leaf-hang") return hangingStream(model, options?.signal);
+  return textStream(model, "coordinator received leaf");
+}
+
+export default function fixtureProvider(pi) {
+  pi.registerTool({
+    name: "fixture_tool",
+    label: "Fixture Tool",
+    description: "Keeps the deterministic model provider inherited",
+    parameters: Type.Object({}),
+    async execute() {
+      return { content: [{ type: "text", text: "fixture tool" }] };
+    },
+  });
+  pi.registerProvider("fixture", {
+    name: "Fixture",
+    baseUrl: "http://fixture.invalid",
+    apiKey: "fixture-key",
+    api: "fixture-api",
+    models: [{
+      id: "model",
+      name: "Fixture Model",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 32000,
+      maxTokens: 1024,
+    }],
+    streamSimple: streamFixture,
+  });
+}
+`;
+
+afterEach(async () => {
+  await Promise.all(temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("native nested subagents", () => {
+  it("retains nested direct work, distinguishes cancellation, and shuts down the lineage", async () => {
+    const temporaryRoot = await mkdtemp(join(tmpdir(), "ompi-subagent-nesting-"));
+    temporaryRoots.push(temporaryRoot);
+    const root = await realpath(temporaryRoot);
+    const agentDir = join(root, "agent");
+    const cwd = join(root, "project");
+    const providerPath = join(root, "nested-provider.ts");
+    const capturePath = join(root, "captures.jsonl");
+    await mkdir(agentDir, { recursive: true });
+    await mkdir(cwd, { recursive: true });
+    await writeFile(join(agentDir, "settings.json"), JSON.stringify({ defaultProjectTrust: "always" }));
+    await writeFile(providerPath, NESTED_PROVIDER_EXTENSION);
+
+    const previous = {
+      agentDir: process.env.PI_CODING_AGENT_DIR,
+      sessionDir: process.env.PI_CODING_AGENT_SESSION_DIR,
+      offline: process.env.PI_OFFLINE,
+      skipVersion: process.env.PI_SKIP_VERSION_CHECK,
+      capture: process.env.OMPI_NESTED_CAPTURE,
+    };
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    process.env.PI_CODING_AGENT_SESSION_DIR = join(root, "sessions");
+    process.env.PI_OFFLINE = "1";
+    process.env.PI_SKIP_VERSION_CHECK = "1";
+    process.env.OMPI_NESTED_CAPTURE = capturePath;
+
+    const capabilities: CapabilitySnapshot = {
+      tools: [
+        { name: "subagent_start", provider: SUBAGENT_EXTENSION },
+        { name: "fixture_tool", provider: providerPath },
+      ],
+      extensionPaths: [SUBAGENT_EXTENSION, providerPath],
+    };
+    const controller = new SubagentController({
+      handshakeMs: 10_000,
+      createChild: async (spec) => {
+        const invocation = buildChildInvocation(spec);
+        return new RpcSubprocess({
+          ...invocation,
+          command: process.execPath,
+          args: [PI_CLI, ...invocation.args],
+        });
+      },
+      onPong: () => {
+        throw new Error("Direct native nesting must not emit a pong.");
+      },
+    });
+
+    try {
+      const result = await controller.run({
+        prompt: "COORDINATOR",
+        cwd,
+        model: "fixture/model",
+        thinking: "off",
+        capabilities,
+        maxDepth: 3,
+        maxChildren: 2,
+      });
+      expect(result).toMatchObject({
+        outcome: "completed",
+        finalText: "coordinator received leaf",
+      });
+
+      const captures = (await readFile(capturePath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      expect(captures.map((capture) => capture.phase)).toEqual([
+        "coordinator-before",
+        "leaf",
+        "coordinator-after",
+      ]);
+      expect(captures[0].pid).toBe(captures[2].pid);
+      expect(captures[1].pid).not.toBe(captures[0].pid);
+
+      const nestedResultText = captures[2].toolResult
+        .filter((item: { type?: string }) => item.type === "text")
+        .map((item: { text: string }) => item.text)
+        .join("");
+      expect(nestedResultText).toContain("[SUBAGENT #1] completed");
+      const leafSession = nestedResultText.match(/Session: ([^\n]+\.jsonl)/)?.[1];
+      expect(leafSession).toBeDefined();
+      if (!leafSession) throw new Error("Nested result did not retain the leaf session reference.");
+
+      const coordinatorSession = await readFile(result.sessionRef, "utf8");
+      const persistedLeafSession = await readFile(leafSession, "utf8");
+      expect(coordinatorSession).toContain("COORDINATOR");
+      expect(coordinatorSession).toContain("coordinator received leaf");
+      expect(persistedLeafSession).toContain("LEAF");
+      expect(persistedLeafSession).toContain("leaf done");
+
+      const cancellation = new AbortController();
+      const cancelling = controller.run({
+        prompt: "CANCEL",
+        cwd,
+        model: "fixture/model",
+        thinking: "off",
+        capabilities,
+        maxDepth: 3,
+        maxChildren: 2,
+      }, cancellation.signal);
+      let cancellationCaptures: Array<{ phase: string; pid: number }> = [];
+      await vi.waitFor(async () => {
+        cancellationCaptures = (await readFile(capturePath, "utf8"))
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line));
+        expect(cancellationCaptures.filter((capture) => capture.phase === "leaf-hang")).toHaveLength(1);
+      }, { timeout: 5_000 });
+      const cancelledCoordinator = cancellationCaptures.findLast(
+        (capture) => capture.phase === "coordinator-before",
+      );
+      const cancelledLeaf = cancellationCaptures.findLast(
+        (capture) => capture.phase === "leaf-hang",
+      );
+      expect(cancelledCoordinator).toBeDefined();
+      expect(cancelledLeaf).toBeDefined();
+      if (!cancelledCoordinator || !cancelledLeaf) {
+        throw new Error("Cancellation lineage processes were not observed.");
+      }
+      cancellation.abort();
+      await expect(cancelling).resolves.toMatchObject({
+        outcome: "interrupted",
+        sessionRef: expect.stringMatching(/\.jsonl$/),
+      });
+      expect(processIsAlive(cancelledCoordinator.pid)).toBe(false);
+      expect(processIsAlive(cancelledLeaf.pid)).toBe(false);
+
+      await controller.start({
+        prompt: "SHUTDOWN",
+        cwd,
+        model: "fixture/model",
+        thinking: "off",
+        capabilities,
+        maxDepth: 3,
+        maxChildren: 2,
+      });
+      let activeCaptures: Array<{ phase: string; pid: number }> = [];
+      await vi.waitFor(async () => {
+        activeCaptures = (await readFile(capturePath, "utf8"))
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line));
+        expect(activeCaptures.filter((capture) => capture.phase === "leaf-hang")).toHaveLength(2);
+      }, { timeout: 5_000 });
+      const activeCoordinator = activeCaptures.findLast(
+        (capture) => capture.phase === "coordinator-before",
+      );
+      const activeLeaf = activeCaptures.findLast((capture) => capture.phase === "leaf-hang");
+      expect(activeCoordinator).toBeDefined();
+      expect(activeLeaf).toBeDefined();
+      if (!activeCoordinator || !activeLeaf) {
+        throw new Error("Shutdown lineage processes were not observed.");
+      }
+      expect(processIsAlive(activeCoordinator.pid)).toBe(true);
+      expect(processIsAlive(activeLeaf.pid)).toBe(true);
+
+      await controller.shutdown();
+      expect(controller.list()).toEqual([]);
+      expect(processIsAlive(activeCoordinator.pid)).toBe(false);
+      expect(processIsAlive(activeLeaf.pid)).toBe(false);
+    } finally {
+      await controller.shutdown();
+      const restore = (name: string, value: string | undefined) => {
+        if (value === undefined) delete process.env[name];
+        else process.env[name] = value;
+      };
+      restore("PI_CODING_AGENT_DIR", previous.agentDir);
+      restore("PI_CODING_AGENT_SESSION_DIR", previous.sessionDir);
+      restore("PI_OFFLINE", previous.offline);
+      restore("PI_SKIP_VERSION_CHECK", previous.skipVersion);
+      restore("OMPI_NESTED_CAPTURE", previous.capture);
+    }
+  }, 30_000);
+});

--- a/extensions/subagents/presentation.test.ts
+++ b/extensions/subagents/presentation.test.ts
@@ -1,7 +1,7 @@
 import { initTheme, type ExtensionAPI, type MessageRenderer } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it } from "vitest";
-import type { Pong, SubagentView } from "./controller.ts";
-import subagentsExtension, { buildActiveUi, buildPongMessage } from "./index.ts";
+import type { SubagentView, TerminalResult } from "./controller.ts";
+import subagentsExtension, { buildActiveUi, buildDirectResult, buildPongMessage } from "./index.ts";
 
 function view(overrides: Partial<SubagentView>): SubagentView {
   return {
@@ -110,7 +110,7 @@ describe("subagent presentation", () => {
   });
 
   it("bounds final assistant text and marks truncation", () => {
-    const pong: Pong = {
+    const pong: TerminalResult = {
       id: 7,
       outcome: "completed",
       sessionRef: "/sessions/7.jsonl",
@@ -122,5 +122,25 @@ describe("subagent presentation", () => {
     expect(message.details.truncated).toBe(true);
     expect(message.content).toContain("truncated to 8,000 characters");
     expect(message.content).toContain("/sessions/7.jsonl");
+  });
+
+  it("keeps the native session reference in bounded direct failure and interruption results", () => {
+    for (const outcome of ["failed", "interrupted"] as const) {
+      const message = buildDirectResult({
+        id: 9,
+        outcome,
+        sessionRef: "/sessions/recover.jsonl",
+        finalText: "x".repeat(8_050),
+        error: outcome === "failed" ? "provider failed" : undefined,
+      });
+
+      expect(message.content).toContain(`[SUBAGENT #9] ${outcome}`);
+      expect(message.content).toContain("/sessions/recover.jsonl");
+      expect(message.details).toMatchObject({
+        outcome,
+        sessionRef: "/sessions/recover.jsonl",
+        truncated: true,
+      });
+    }
   });
 });

--- a/extensions/subagents/rpc-child.test.ts
+++ b/extensions/subagents/rpc-child.test.ts
@@ -17,6 +17,7 @@ describe("buildChildInvocation", () => {
       cwd: "/tmp/worktree",
       model: "anthropic/claude",
       thinking: "high",
+      lineage: { depth: 2, maxDepth: 3, maxChildren: 2 },
       capabilities: {
         tools: [
           { name: "read", provider: BUILTIN_TOOL_PROVIDER },
@@ -29,6 +30,9 @@ describe("buildChildInvocation", () => {
 
     expect(invocation.cwd).toBe("/tmp/worktree");
     expect(invocation.env.PATH).toBe(process.env.PATH);
+    expect(invocation.env.OMPI_SUBAGENT_LINEAGE).toBe(
+      '{"version":1,"depth":2,"maxDepth":3,"maxChildren":2}',
+    );
     expect(invocation.args).toContain("--no-extensions");
     expect(valuesAfter(invocation.args, "--extension")).toEqual([
       "/extensions/browser-fetch/index.ts",
@@ -50,11 +54,13 @@ describe("buildChildInvocation", () => {
       model: "openai/gpt",
       thinking: "low",
       capabilities: { tools: [], extensionPaths: [] },
+      lineage: { depth: 2, maxDepth: 2, maxChildren: 0 },
       name: "existing",
       session: "/sessions/child.jsonl",
     });
 
     expect(valueAfter(invocation.args, "--session")).toBe("/sessions/child.jsonl");
+    expect(invocation.env.OMPI_SUBAGENT_LINEAGE).toContain('"depth":2');
     expect(invocation.args).not.toContain("--name");
     expect(invocation.args).toContain("--no-tools");
     expect(invocation.args).not.toContain("--tools");

--- a/extensions/subagents/rpc-child.ts
+++ b/extensions/subagents/rpc-child.ts
@@ -9,6 +9,7 @@ import {
   type CapabilitySnapshot,
 } from "./capabilities.ts";
 import type { LaunchSpec, RpcChild, RpcEvent } from "./controller.ts";
+import { MANAGED_LINEAGE_ENV, encodeManagedLineage } from "./lineage.ts";
 
 interface RpcResponse {
   id?: string;
@@ -35,6 +36,10 @@ export interface ChildInvocation {
 
 export function buildChildInvocation(spec: LaunchSpec): ChildInvocation {
   const args = ["--mode", "rpc", "--no-extensions"];
+  const env = {
+    ...process.env,
+    [MANAGED_LINEAGE_ENV]: encodeManagedLineage(spec.lineage),
+  };
   for (const extensionPath of spec.capabilities.extensionPaths) {
     args.push("--extension", extensionPath);
   }
@@ -52,7 +57,7 @@ export function buildChildInvocation(spec: LaunchSpec): ChildInvocation {
   const currentScript = process.argv[1];
   const isBunVirtualScript = currentScript?.startsWith("/$bunfs/root/");
   if (currentScript && !isBunVirtualScript && existsSync(currentScript)) {
-    return { command: process.execPath, args: [currentScript, ...args], cwd: spec.cwd, env: { ...process.env } };
+    return { command: process.execPath, args: [currentScript, ...args], cwd: spec.cwd, env };
   }
 
   const executable = basename(process.execPath).toLowerCase();
@@ -61,7 +66,7 @@ export function buildChildInvocation(spec: LaunchSpec): ChildInvocation {
     command: genericRuntime ? "pi" : process.execPath,
     args,
     cwd: spec.cwd,
-    env: { ...process.env },
+    env,
   };
 }
 


### PR DESCRIPTION
## Summary

- add one-based managed delegation depth and monotonic local direct-child ceilings
- support explicit direct start and continuation delivery while preserving asynchronous and print-mode contracts
- recursively own nested runtime cleanup, distinguish caller cancellation, and retain native session references
- document the nested lifecycle and cover it with deterministic controller and native-process tests

## Verification

- `npm test` — 19 files, 154 tests passed
- `npm run typecheck` — passed
- `git diff --check e6590fae7c6a79249f09a0a4162e1556082f54b3...HEAD` — passed

## Review

One isolated read-only review found a direct-continuation cancellation race. The coordinator fixed it in `40d947e` and added regression coverage before final verification.

Closes #28
