### PR TITLE
feat: expose nested lineage status and relay dialogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,16 @@ exactly one completion, failure, or interruption pong. Set `delivery` to
 result through the pending tool call; direct delivery emits no later pong.
 Independent direct siblings issued together still run concurrently.
 
+The normal widget and footer remain compact and show only direct current
+activity. They never stream child transcripts into the parent conversation or
+render a recursive dashboard. When a user asks to inspect nesting,
+`subagent_status` or `/subtree` returns the active ownership subtree relative to
+the invoking parent: `self`, depth, state, parent runtime, and owner-local
+numeric ID. A nested parent therefore sees itself and descendants, not its
+parent, siblings, idle conversations, unrelated controllers, or other sessions.
+Descendant paths explain ownership but are not new action identifiers; existing
+steer and interrupt operations still accept only the direct owner's local ID.
+
 After asynchronous acceptance, the parent must not sleep, run a wait loop, or
 repeatedly call `subagent_list` for completion. When multiple independent
 delegations are useful, it starts them in the same turn so Pi can run them
@@ -409,7 +419,8 @@ The extension exposes these tools and matching commands:
 | `subagent_continue` | `/subcont` | Continue a settled conversation |
 | `subagent_steer` | `/substeer` | Steer an active turn |
 | `subagent_interrupt` | `/substop` | Interrupt an active turn |
-| `subagent_list` | `/sublist` | List session-scoped known conversations |
+| `subagent_status` | `/subtree` | Show the active ownership subtree on demand |
+| `subagent_list` | `/sublist` | List direct session-scoped known conversations |
 
 Use plain command arguments for common operations, or JSON with `/sub` and
 `/subcont` for delivery, lineage ceilings, routing, working-directory, tool, and
@@ -437,6 +448,7 @@ neither value can be raised. For example:
 /subcont 1 Check the newly changed files.
 /substeer 1 Focus only on the parser.
 /substop 1
+/subtree
 /sublist
 ```
 
@@ -468,6 +480,16 @@ session reference for complete inspection, including truncated, failed,
 interrupted, and missing-assistant-message cases. The registry is intentionally
 in memory; native Pi JSONL sessions remain after processes and the orchestrator
 exit.
+
+Standard `select`, `confirm`, `input`, and `editor` dialogs requested by a
+headless child relay mechanically through direct owners to a root TUI. Parent
+models never receive or answer the dialog content. Relay requests remain
+correlated and settle within thirty seconds; process cleanup cancels pending
+dialogs. If the root is print, JSON, RPC without a TUI, absent, or unresponsive,
+the child receives the standard cancellation value instead of hanging. Pi's
+TUI-only `ctx.ui.custom()` remains unavailable in RPC children and the extension
+does not emulate it. Fire-and-forget child UI components are not turned into a
+root dashboard.
 
 Install dependencies and verify the extension with:
 

--- a/docs/subagents/CONTEXT.md
+++ b/docs/subagents/CONTEXT.md
@@ -80,9 +80,17 @@ _Avoid_: Pong, completion
 The subagent extension's single deterministic asynchronous notification that an accepted subagent turn completed, failed, or was interrupted. It carries the bounded terminal result and its native session reference; delivery never depends on the subagent producing an assistant message. Direct delivery never emits a pong.
 _Avoid_: Direct result, model callback, polling, status check
 
+**Ownership subtree**:
+One parent agent plus every active descendant runtime reachable through that parent's direct children. An on-demand snapshot identifies the invoking parent as `self`; descendant runtime paths are relative to it, while each `#ID` remains scoped to the direct owner named on that line. A parent can inspect only its own subtree, never its parent, siblings, unrelated controllers, idle conversations, or other sessions. Existing direct-owner steering and interruption operations continue to accept their local numeric IDs; the status view adds no tree action API, and closing an ancestor retains recursive managed-lineage cleanup.
+_Avoid_: Global agent registry, session inventory, machine process tree, globally actionable runtime ID
+
 **Live status**:
-A compact Pi widget near the editor that shows current subagent activity without adding streaming updates to the orchestrator conversation. A minimal footer count remains visible while any subagent turn is active. The same active count is published through the shared extension event bus so session-level status integrations do not mistake a settled orchestrator turn for an idle session.
-_Avoid_: Transcript message, progress polling, full output
+A compact Pi widget near the editor that shows only direct current subagent activity without adding streaming updates to the parent conversation. The default stays non-recursive, and a minimal footer count remains visible while a direct subagent turn is active. The same direct active count is published through the shared extension event bus so session-level status integrations do not mistake a settled parent turn for an idle session. `subagent_status` and `/subtree` provide a user-requested, active-only ownership subtree; status propagation contains bounded runtime metadata, never prompts, transcript text, final text, unrelated sessions, or a permanent dashboard.
+_Avoid_: Transcript message, progress polling, full output, recursive default widget
+
+**Headless UI relay**:
+The mechanical owner-chain transport for standard RPC dialogs: `select`, `confirm`, `input`, and `editor`. Each direct owner forwards the request through RPC UI rather than exposing it to its model, and only a root TUI may ask the user. The correlated user response returns along the same chain. Every relay is capped at thirty seconds and process cleanup cancels pending requests; absent, unresponsive, non-TUI, print, JSON, or root RPC surfaces return the protocol's method-appropriate cancellation instead of hanging. Pi's TUI-only `custom()` remains unavailable in headless RPC children and is not represented or emulated by this extension.
+_Avoid_: Child TUI, model-authored user response, automatic approval, custom-component emulation
 
 ## Routing selection
 

--- a/extensions/subagents/controller.test.ts
+++ b/extensions/subagents/controller.test.ts
@@ -138,6 +138,30 @@ async function settle(child: FakeChild): Promise<void> {
 }
 
 describe("SubagentController", () => {
+  it("rolls back a new active record when pre-launch status publication fails", async () => {
+    let launches = 0;
+    const controller = new SubagentController({
+      createChild: async (spec) => {
+        launches++;
+        return new FakeChild(spec, "/sessions/unexpected.jsonl");
+      },
+      onPong: () => undefined,
+      onChange: () => {
+        throw new Error("status publication failed");
+      },
+    });
+
+    await expect(controller.start({
+      prompt: "not launched",
+      cwd: "/repo",
+      model: "p/m",
+      thinking: "low",
+      capabilities: DEFAULT_CAPABILITIES,
+    })).rejects.toThrow("status publication failed");
+    expect(launches).toBe(0);
+    expect(controller.list()).toEqual([]);
+  });
+
   it("returns after prompt acceptance and before completion", async () => {
     const { controller, children, pongs } = setup({ delayedPrompt: true });
     const starting = controller.start({ prompt: "inspect", cwd: "/repo", model: "p/m", thinking: "high", capabilities: DEFAULT_CAPABILITIES });

--- a/extensions/subagents/controller.test.ts
+++ b/extensions/subagents/controller.test.ts
@@ -589,6 +589,96 @@ describe("SubagentController", () => {
     expect(controller.list()[0]).toMatchObject({ preview: "visible", currentTool: "read" });
   });
 
+  it("reports only the active owned subtree and removes descendants on child settlement", async () => {
+    const { controller, children } = setup();
+    await controller.start({
+      prompt: "coordinate",
+      name: "coordinator",
+      cwd: "/repo",
+      model: "p/coordinator",
+      thinking: "low",
+      capabilities: DEFAULT_CAPABILITIES,
+    });
+    children[0].emit({
+      type: "subagent_ownership",
+      ownership: [{
+        path: [4],
+        parentPath: [],
+        id: 4,
+        depth: 3,
+        state: "running",
+        name: "leaf",
+        model: "p/leaf",
+        thinking: "medium",
+      }],
+    } as RpcEvent);
+
+    expect(controller.activeSubtree()).toEqual([
+      {
+        path: [1],
+        parentPath: [],
+        id: 1,
+        depth: 2,
+        state: "running",
+        name: "coordinator",
+        model: "p/coordinator",
+        thinking: "low",
+      },
+      {
+        path: [1, 4],
+        parentPath: [1],
+        id: 4,
+        depth: 3,
+        state: "running",
+        name: "leaf",
+        model: "p/leaf",
+        thinking: "medium",
+      },
+    ]);
+
+    await settle(children[0]);
+    expect(controller.activeSubtree()).toEqual([]);
+  });
+
+  it("prefixes each propagated subtree with its direct owner and cannot expose siblings", async () => {
+    const { controller, children } = setup();
+    const input = {
+      cwd: "/repo",
+      model: "p/owner",
+      thinking: "low" as const,
+      capabilities: DEFAULT_CAPABILITIES,
+    };
+    await Promise.all([
+      controller.start({ ...input, prompt: "one" }),
+      controller.start({ ...input, prompt: "two" }),
+    ]);
+    children[0].emit({
+      type: "subagent_ownership",
+      ownership: [{
+        path: [2], parentPath: [], id: 2, depth: 3, state: "running",
+        model: "p/leaf-one", thinking: "low",
+      }],
+    });
+    children[1].emit({
+      type: "subagent_ownership",
+      ownership: [{
+        path: [2], parentPath: [], id: 2, depth: 3, state: "running",
+        model: "p/leaf-two", thinking: "low",
+      }],
+    });
+
+    expect(controller.activeSubtree().map((runtime) => ({
+      path: runtime.path,
+      parentPath: runtime.parentPath,
+      model: runtime.model,
+    }))).toEqual([
+      { path: [1], parentPath: [], model: "p/owner" },
+      { path: [1, 2], parentPath: [1], model: "p/leaf-one" },
+      { path: [2], parentPath: [], model: "p/owner" },
+      { path: [2, 2], parentPath: [2], model: "p/leaf-two" },
+    ]);
+  });
+
   it("suppresses pongs and clears state on shutdown", async () => {
     const { controller, children, pongs } = setup();
     await Promise.all([

--- a/extensions/subagents/controller.ts
+++ b/extensions/subagents/controller.ts
@@ -12,7 +12,19 @@ import {
 
 export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 export type TerminalOutcome = "completed" | "failed" | "interrupted";
-export type SubagentState = "handshaking" | "running" | "steering" | "interrupting" | "finalizing" | TerminalOutcome;
+export type ActiveSubagentState = "handshaking" | "running" | "steering" | "interrupting" | "finalizing";
+export type SubagentState = ActiveSubagentState | TerminalOutcome;
+
+export interface OwnershipRuntime {
+  path: number[];
+  parentPath: number[];
+  id: number;
+  depth: number;
+  state: ActiveSubagentState;
+  name?: string;
+  model: string;
+  thinking: ThinkingLevel;
+}
 
 export interface LaunchSpec {
   cwd: string;
@@ -29,6 +41,7 @@ export interface RpcEvent {
   toolName?: string;
   assistantMessageEvent?: { type?: string; delta?: string };
   message?: { role?: string; stopReason?: string; errorMessage?: string };
+  ownership?: OwnershipRuntime[];
 }
 
 export interface RpcChild {
@@ -92,6 +105,7 @@ interface RecordState extends SubagentView {
   pendingExitError?: string;
   terminalError?: string;
   assistantMessageEnded: boolean;
+  ownership: OwnershipRuntime[];
   directResolve?: (result: TerminalResult) => void;
 }
 
@@ -135,10 +149,32 @@ export class SubagentController {
   }
 
   list(): SubagentView[] {
-    return [...this.records.values()].map(({ capabilities, lineage: _lineage, child: _child, accepted: _accepted, finalizing: _finalizing, delivered: _delivered, interruptRequested: _interruptRequested, pendingSettled: _pendingSettled, pendingExitError: _pendingExitError, terminalError: _terminalError, assistantMessageEnded: _assistantMessageEnded, directResolve: _directResolve, ...view }) => ({
+    return [...this.records.values()].map(({ capabilities, lineage: _lineage, child: _child, accepted: _accepted, finalizing: _finalizing, delivered: _delivered, interruptRequested: _interruptRequested, pendingSettled: _pendingSettled, pendingExitError: _pendingExitError, terminalError: _terminalError, assistantMessageEnded: _assistantMessageEnded, ownership: _ownership, directResolve: _directResolve, ...view }) => ({
       ...view,
       tools: capabilities.tools.map((tool) => tool.name),
     }));
+  }
+
+  activeSubtree(): OwnershipRuntime[] {
+    return [...this.records.values()].flatMap((record) => {
+      if (!record.active) return [];
+      const direct: OwnershipRuntime = {
+        path: [record.id],
+        parentPath: [],
+        id: record.id,
+        depth: record.lineage.depth,
+        state: record.state as ActiveSubagentState,
+        name: record.name,
+        model: record.model,
+        thinking: record.thinking,
+      };
+      const descendants = record.ownership.map((runtime) => ({
+        ...runtime,
+        path: [record.id, ...runtime.path],
+        parentPath: [record.id, ...runtime.parentPath],
+      }));
+      return [direct, ...descendants];
+    });
   }
 
   async start(input: StartInput): Promise<SubagentView> {
@@ -257,6 +293,7 @@ export class SubagentController {
     record.pendingExitError = undefined;
     record.terminalError = undefined;
     record.assistantMessageEnded = false;
+    record.ownership = [];
     record.directResolve = directResolve;
     this.changed();
 
@@ -370,6 +407,14 @@ export class SubagentController {
 
   private handleEvent(record: RecordState, event: RpcEvent): void {
     if (!record.active || record.finalizing) return;
+    if (event.type === "subagent_ownership") {
+      record.ownership = (event.ownership ?? []).filter((runtime) => (
+        runtime.depth === record.lineage.depth + runtime.path.length
+        && runtime.depth <= record.lineage.maxDepth
+      ));
+      this.changed();
+      return;
+    }
     if (event.type === "agent_settled") {
       if (!record.accepted) {
         record.pendingSettled = true;
@@ -437,6 +482,7 @@ export class SubagentController {
     record.active = false;
     record.startedAt = undefined;
     record.currentTool = undefined;
+    record.ownership = [];
     record.state = outcome;
     record.finalizing = false;
     record.error = record.error || undefined;
@@ -478,6 +524,7 @@ export class SubagentController {
       interruptRequested: false,
       pendingSettled: false,
       assistantMessageEnded: false,
+      ownership: [],
       directResolve,
     };
     this.records.set(record.id, record);

--- a/extensions/subagents/controller.ts
+++ b/extensions/subagents/controller.ts
@@ -295,9 +295,9 @@ export class SubagentController {
     record.assistantMessageEnded = false;
     record.ownership = [];
     record.directResolve = directResolve;
-    this.changed();
 
     try {
+      this.changed();
       await this.launch(record, input.prompt);
       return this.view(record);
     } catch (error) {
@@ -528,8 +528,13 @@ export class SubagentController {
       directResolve,
     };
     this.records.set(record.id, record);
-    this.changed();
-    return record;
+    try {
+      this.changed();
+      return record;
+    } catch (error) {
+      this.records.delete(record.id);
+      throw error;
+    }
   }
 
   private assertCanLaunch(): void {

--- a/extensions/subagents/dialogs.ts
+++ b/extensions/subagents/dialogs.ts
@@ -1,0 +1,238 @@
+import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+
+export const STANDARD_DIALOG_METHODS = ["select", "confirm", "input", "editor"] as const;
+export const DIALOG_RELAY_TIMEOUT_MS = 30_000;
+export type StandardDialogMethod = (typeof STANDARD_DIALOG_METHODS)[number];
+
+interface DialogBase {
+  id: string;
+  method: StandardDialogMethod;
+  title: string;
+  timeout?: number;
+}
+
+export interface SelectDialogRequest extends DialogBase {
+  method: "select";
+  options: string[];
+}
+
+export interface ConfirmDialogRequest extends DialogBase {
+  method: "confirm";
+  message: string;
+}
+
+export interface InputDialogRequest extends DialogBase {
+  method: "input";
+  placeholder?: string;
+}
+
+export interface EditorDialogRequest extends DialogBase {
+  method: "editor";
+  prefill?: string;
+}
+
+export type StandardDialogRequest =
+  | SelectDialogRequest
+  | ConfirmDialogRequest
+  | InputDialogRequest
+  | EditorDialogRequest;
+
+export type StandardDialogResult =
+  | { cancelled: true }
+  | { confirmed: boolean }
+  | { value: string };
+
+const MAX_ID_LENGTH = 128;
+const MAX_TITLE_LENGTH = 2_000;
+const MAX_TEXT_LENGTH = 8_000;
+const MAX_OPTION_LENGTH = 1_000;
+const MAX_OPTIONS = 100;
+const MAX_TIMEOUT_MS = 120_000;
+const METHOD_SET = new Set<string>(STANDARD_DIALOG_METHODS);
+
+function invalid(): never {
+  throw new Error("Standard child dialog request is invalid.");
+}
+
+function boundedString(value: unknown, maximum: number, optional = false): string | undefined {
+  if (value === undefined && optional) return undefined;
+  if (typeof value !== "string" || value.length > maximum || /[\u0000]/.test(value)) invalid();
+  return value;
+}
+
+function timeout(value: unknown): number | undefined {
+  if (value === undefined) return undefined;
+  if (!Number.isInteger(value) || Number(value) <= 0 || Number(value) > MAX_TIMEOUT_MS) invalid();
+  return Number(value);
+}
+
+function exactKeys(value: Record<string, unknown>, allowed: string[]): void {
+  const keys = new Set(allowed);
+  if (Object.keys(value).some((key) => !keys.has(key))) invalid();
+}
+
+export function isStandardDialogMethod(value: unknown): value is StandardDialogMethod {
+  return typeof value === "string" && METHOD_SET.has(value);
+}
+
+export function parseStandardDialogRequest(value: unknown): StandardDialogRequest {
+  if (!value || typeof value !== "object" || Array.isArray(value)) invalid();
+  const candidate = value as Record<string, unknown>;
+  if (
+    candidate.type !== "extension_ui_request"
+    || typeof candidate.id !== "string"
+    || candidate.id.length === 0
+    || candidate.id.length > MAX_ID_LENGTH
+    || !isStandardDialogMethod(candidate.method)
+  ) {
+    invalid();
+  }
+  const parsedTimeout = timeout(candidate.timeout);
+  const base = {
+    id: candidate.id,
+    title: boundedString(candidate.title, MAX_TITLE_LENGTH) ?? "",
+    ...(parsedTimeout === undefined ? {} : { timeout: parsedTimeout }),
+  };
+  switch (candidate.method) {
+    case "select": {
+      exactKeys(candidate, ["type", "id", "method", "title", "options", "timeout"]);
+      if (
+        !Array.isArray(candidate.options)
+        || candidate.options.length > MAX_OPTIONS
+        || candidate.options.some((option) => (
+          typeof option !== "string"
+          || option.length > MAX_OPTION_LENGTH
+          || /[\u0000]/.test(option)
+        ))
+      ) {
+        invalid();
+      }
+      return { ...base, method: "select", options: [...candidate.options] };
+    }
+    case "confirm":
+      exactKeys(candidate, ["type", "id", "method", "title", "message", "timeout"]);
+      return {
+        ...base,
+        method: "confirm",
+        message: boundedString(candidate.message, MAX_TEXT_LENGTH) ?? "",
+      };
+    case "input":
+      exactKeys(candidate, ["type", "id", "method", "title", "placeholder", "timeout"]);
+      const placeholder = boundedString(candidate.placeholder, MAX_TEXT_LENGTH, true);
+      return {
+        ...base,
+        method: "input",
+        ...(placeholder === undefined ? {} : { placeholder }),
+      };
+    case "editor":
+      exactKeys(candidate, ["type", "id", "method", "title", "prefill", "timeout"]);
+      const prefill = boundedString(candidate.prefill, MAX_TEXT_LENGTH, true);
+      return {
+        ...base,
+        method: "editor",
+        ...(prefill === undefined ? {} : { prefill }),
+      };
+  }
+}
+
+export function cancelledDialogResult(): StandardDialogResult {
+  return { cancelled: true };
+}
+
+const RELAY_CANCELLED = Symbol("relay-cancelled");
+
+async function withinRelayDeadline<T>(
+  operation: Promise<T>,
+  signal: AbortSignal,
+  timeoutMs: number,
+): Promise<T | typeof RELAY_CANCELLED> {
+  if (signal.aborted) return RELAY_CANCELLED;
+  let timer: number | NodeJS.Timeout | undefined;
+  let abort: (() => void) | undefined;
+  const cancelled = new Promise<typeof RELAY_CANCELLED>((resolve) => {
+    abort = () => resolve(RELAY_CANCELLED);
+    signal.addEventListener("abort", abort, { once: true });
+    timer = setTimeout(() => resolve(RELAY_CANCELLED), timeoutMs);
+  });
+  try {
+    return await Promise.race([operation, cancelled]);
+  } finally {
+    if (timer) clearTimeout(timer);
+    if (abort) signal.removeEventListener("abort", abort);
+  }
+}
+
+export async function relayStandardDialog(
+  ui: ExtensionUIContext,
+  request: StandardDialogRequest,
+  signal: AbortSignal,
+): Promise<StandardDialogResult> {
+  if (signal.aborted) return cancelledDialogResult();
+  const relayTimeout = Math.min(request.timeout ?? DIALOG_RELAY_TIMEOUT_MS, DIALOG_RELAY_TIMEOUT_MS);
+  const settings = { signal, timeout: relayTimeout };
+  try {
+    switch (request.method) {
+      case "select": {
+        const value = await withinRelayDeadline(
+          ui.select(request.title, request.options, settings),
+          signal,
+          relayTimeout,
+        );
+        return value === RELAY_CANCELLED || value === undefined
+          ? cancelledDialogResult()
+          : { value };
+      }
+      case "confirm": {
+        const confirmed = await withinRelayDeadline(
+          ui.confirm(request.title, request.message, settings),
+          signal,
+          relayTimeout,
+        );
+        return confirmed === RELAY_CANCELLED
+          ? cancelledDialogResult()
+          : { confirmed };
+      }
+      case "input": {
+        const value = await withinRelayDeadline(
+          ui.input(request.title, request.placeholder, settings),
+          signal,
+          relayTimeout,
+        );
+        return value === RELAY_CANCELLED || value === undefined
+          ? cancelledDialogResult()
+          : { value };
+      }
+      case "editor": {
+        const value = await withinRelayDeadline(
+          ui.editor(request.title, request.prefill),
+          signal,
+          relayTimeout,
+        );
+        return value === RELAY_CANCELLED || value === undefined
+          ? cancelledDialogResult()
+          : { value };
+      }
+    }
+  } catch {
+    return cancelledDialogResult();
+  }
+}
+
+export function normalizeDialogResult(
+  request: StandardDialogRequest,
+  result: StandardDialogResult,
+): StandardDialogResult {
+  if ("cancelled" in result && result.cancelled === true) return cancelledDialogResult();
+  if (request.method === "confirm") {
+    return "confirmed" in result && typeof result.confirmed === "boolean"
+      ? { confirmed: result.confirmed }
+      : cancelledDialogResult();
+  }
+  if (!("value" in result) || typeof result.value !== "string" || result.value.length > MAX_TEXT_LENGTH) {
+    return cancelledDialogResult();
+  }
+  if (request.method === "select" && !request.options.includes(result.value)) {
+    return cancelledDialogResult();
+  }
+  return { value: result.value };
+}

--- a/extensions/subagents/dialogs.ts
+++ b/extensions/subagents/dialogs.ts
@@ -1,4 +1,7 @@
-import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import {
+  ExtensionEditorComponent,
+  type ExtensionUIContext,
+} from "@earendil-works/pi-coding-agent";
 
 export const STANDARD_DIALOG_METHODS = ["select", "confirm", "input", "editor"] as const;
 export const DIALOG_RELAY_TIMEOUT_MS = 30_000;
@@ -41,6 +44,10 @@ export type StandardDialogResult =
   | { cancelled: true }
   | { confirmed: boolean }
   | { value: string };
+
+export interface DialogRelayOptions {
+  interactiveEditor?: boolean;
+}
 
 const MAX_ID_LENGTH = 128;
 const MAX_TITLE_LENGTH = 2_000;
@@ -162,10 +169,55 @@ async function withinRelayDeadline<T>(
   }
 }
 
+async function relayInteractiveEditor(
+  ui: ExtensionUIContext,
+  request: EditorDialogRequest,
+  signal: AbortSignal,
+  timeoutMs: number,
+): Promise<StandardDialogResult> {
+  if (signal.aborted) return cancelledDialogResult();
+  let cleanup = () => undefined;
+  try {
+    const value = await ui.custom<string | undefined>((tui, _theme, keybindings, done) => {
+      let settled = false;
+      let timer: NodeJS.Timeout | undefined;
+      const finish = (result: string | undefined) => {
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
+        signal.removeEventListener("abort", abort);
+        done(result);
+      };
+      const abort = () => finish(undefined);
+      cleanup = () => {
+        if (timer) clearTimeout(timer);
+        signal.removeEventListener("abort", abort);
+      };
+      signal.addEventListener("abort", abort, { once: true });
+      timer = setTimeout(() => finish(undefined), timeoutMs);
+      if (signal.aborted) queueMicrotask(abort);
+      return new ExtensionEditorComponent(
+        tui,
+        keybindings,
+        request.title,
+        request.prefill,
+        (result) => finish(result),
+        () => finish(undefined),
+      );
+    });
+    return value === undefined ? cancelledDialogResult() : { value };
+  } catch {
+    return cancelledDialogResult();
+  } finally {
+    cleanup();
+  }
+}
+
 export async function relayStandardDialog(
   ui: ExtensionUIContext,
   request: StandardDialogRequest,
   signal: AbortSignal,
+  options: DialogRelayOptions = {},
 ): Promise<StandardDialogResult> {
   if (signal.aborted) return cancelledDialogResult();
   const relayTimeout = Math.min(request.timeout ?? DIALOG_RELAY_TIMEOUT_MS, DIALOG_RELAY_TIMEOUT_MS);
@@ -203,6 +255,9 @@ export async function relayStandardDialog(
           : { value };
       }
       case "editor": {
+        if (options.interactiveEditor) {
+          return relayInteractiveEditor(ui, request, signal, relayTimeout);
+        }
         const value = await withinRelayDeadline(
           ui.editor(request.title, request.prefill),
           signal,

--- a/extensions/subagents/index.ts
+++ b/extensions/subagents/index.ts
@@ -265,7 +265,10 @@ export default function subagentsExtension(pi: ExtensionAPI) {
     const views = controller.list();
     const activeCount = views.filter((view) => view.active).length;
     const presentation = buildActiveUi(views, Date.now());
-    if (ui && uiMode === "tui") {
+    if (
+      ui
+      && (uiMode === "tui" || (lineage.depth === 1 && uiMode === "rpc"))
+    ) {
       const theme = ui.theme;
       ui.setWidget(
         "subagents",
@@ -308,7 +311,9 @@ export default function subagentsExtension(pi: ExtensionAPI) {
     ) {
       return cancelledDialogResult();
     }
-    return relayStandardDialog(currentUi, request, signal);
+    return relayStandardDialog(currentUi, request, signal, {
+      interactiveEditor: lineage.depth === 1 && uiMode === "tui",
+    });
   };
 
   const sendPong = (pong: TerminalResult) => {
@@ -589,7 +594,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
     if (timer) clearInterval(timer);
     timer = undefined;
     await controller.shutdown();
-    if (uiMode === "tui") {
+    if (uiMode === "tui" || (lineage.depth === 1 && uiMode === "rpc")) {
       ui?.setWidget("subagents", undefined);
       ui?.setStatus("subagents", undefined);
     }

--- a/extensions/subagents/index.ts
+++ b/extensions/subagents/index.ts
@@ -14,11 +14,22 @@ import {
   type TerminalResult,
   type SubagentView,
   type ThinkingLevel,
+  type OwnershipRuntime,
 } from "./controller.ts";
 import { buildChildInvocation, RpcSubprocess } from "./rpc-child.ts";
 import { captureCapabilities } from "./capabilities.ts";
 import { publishAsyncActivity } from "./async-activity.ts";
+import {
+  cancelledDialogResult,
+  relayStandardDialog,
+  type StandardDialogRequest,
+  type StandardDialogResult,
+} from "./dialogs.ts";
 import { readManagedLineage } from "./lineage.ts";
+import {
+  OWNERSHIP_STATUS_KEY,
+  encodeOwnershipStatus,
+} from "./ownership.ts";
 
 const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
 const THINKING_LEVEL_SET = new Set<string>(THINKING_LEVELS);
@@ -153,6 +164,49 @@ export function buildActiveUi(views: SubagentView[], now: number): { lines?: str
   return { lines, status: `subagents: ${active.length}` };
 }
 
+interface OwnershipStatusNode {
+  runtimeId: string;
+  parentRuntimeId?: string;
+  managementId?: number;
+  depth: number;
+  state: "current" | OwnershipRuntime["state"];
+  name?: string;
+  model?: string;
+  thinking?: ThinkingLevel;
+}
+
+export function buildOwnershipStatus(
+  depth: number,
+  ownership: OwnershipRuntime[],
+): { lines: string[]; nodes: OwnershipStatusNode[] } {
+  const nodes: OwnershipStatusNode[] = [
+    { runtimeId: "self", depth, state: "current" },
+    ...ownership.map((runtime) => ({
+      runtimeId: runtime.path.join("/"),
+      parentRuntimeId: runtime.parentPath.length > 0 ? runtime.parentPath.join("/") : "self",
+      managementId: runtime.id,
+      depth: runtime.depth,
+      state: runtime.state,
+      name: runtime.name,
+      model: runtime.model,
+      thinking: runtime.thinking,
+    })),
+  ];
+  const lines = ["self · depth " + depth + " · current owner"];
+  for (const runtime of ownership) {
+    const runtimeId = runtime.path.join("/");
+    const parentRuntimeId = runtime.parentPath.length > 0 ? runtime.parentPath.join("/") : "self";
+    const name = runtime.name ? ` (${oneLine(runtime.name, 40)})` : "";
+    const indent = "  ".repeat(Math.max(0, runtime.path.length - 1));
+    lines.push(
+      `${indent}└─ runtime ${runtimeId}${name} · depth ${runtime.depth} · ${runtime.state}`
+      + ` · parent ${parentRuntimeId} · owner-local ID #${runtime.id}`
+      + ` · ${oneLine(runtime.model, 80)} · reasoning ${runtime.thinking}`,
+    );
+  }
+  return { lines, nodes };
+}
+
 function buildTerminalMessage(
   pong: TerminalResult,
   heading: string,
@@ -201,15 +255,17 @@ export default function subagentsExtension(pi: ExtensionAPI) {
   });
 
   let ui: ExtensionContext["ui"] | undefined;
+  let uiMode: ExtensionContext["mode"] | undefined;
   let timer: NodeJS.Timeout | undefined;
   let publishedActiveCount: number | undefined;
+  let publishedOwnershipStatus: string | undefined;
   let controller: SubagentController;
 
   const refreshUi = () => {
     const views = controller.list();
     const activeCount = views.filter((view) => view.active).length;
     const presentation = buildActiveUi(views, Date.now());
-    if (ui) {
+    if (ui && uiMode === "tui") {
       const theme = ui.theme;
       ui.setWidget(
         "subagents",
@@ -220,6 +276,13 @@ export default function subagentsExtension(pi: ExtensionAPI) {
         presentation.status ? theme.fg("success", presentation.status) : undefined,
       );
     }
+    if (ui && lineage.depth > 1 && uiMode === "rpc") {
+      const ownershipStatus = encodeOwnershipStatus(controller.activeSubtree());
+      if (publishedOwnershipStatus !== ownershipStatus) {
+        publishedOwnershipStatus = ownershipStatus;
+        ui.setStatus(OWNERSHIP_STATUS_KEY, ownershipStatus);
+      }
+    }
     if (activeCount > 0 && !timer) timer = setInterval(refreshUi, 1_000);
     if (activeCount === 0 && timer) {
       clearInterval(timer);
@@ -229,6 +292,23 @@ export default function subagentsExtension(pi: ExtensionAPI) {
       publishedActiveCount = activeCount;
       publishAsyncActivity(pi, "subagents", activeCount);
     }
+  };
+
+  const relayDialog = async (
+    request: StandardDialogRequest,
+    signal: AbortSignal,
+  ): Promise<StandardDialogResult> => {
+    const currentUi = ui;
+    if (
+      !currentUi
+      || !(
+        (lineage.depth === 1 && uiMode === "tui")
+        || (lineage.depth > 1 && uiMode === "rpc")
+      )
+    ) {
+      return cancelledDialogResult();
+    }
+    return relayStandardDialog(currentUi, request, signal);
   };
 
   const sendPong = (pong: TerminalResult) => {
@@ -246,7 +326,10 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 
   controller = new SubagentController({
     lineage,
-    createChild: async (spec) => new RpcSubprocess(buildChildInvocation(spec)),
+    createChild: async (spec) => new RpcSubprocess(
+      buildChildInvocation(spec),
+      { onDialog: relayDialog },
+    ),
     onPong: sendPong,
     onChange: refreshUi,
   });
@@ -371,6 +454,29 @@ export default function subagentsExtension(pi: ExtensionAPI) {
   });
 
   pi.registerTool({
+    name: "subagent_status",
+    label: "Subagent Ownership Status",
+    description: "Take one on-demand snapshot of this parent's active ownership subtree. It includes self and active descendants with depth, state, parent relationships, and owner-scoped runtime IDs; it never includes transcripts or unrelated sessions and adds no management controls.",
+    promptGuidelines: [
+      "Use subagent_status only for a user-requested ownership snapshot or a concrete orchestration decision; never poll it for completion.",
+    ],
+    parameters: ListSchema,
+    async execute() {
+      const status = buildOwnershipStatus(lineage.depth, controller.activeSubtree());
+      return {
+        content: [{
+          type: "text",
+          text: [
+            "Active ownership subtree (IDs are scoped to the runtime's direct owner):",
+            ...status.lines,
+          ].join("\n"),
+        }],
+        details: status,
+      };
+    },
+  });
+
+  pi.registerTool({
     name: "subagent_list",
     label: "List Subagents",
     description: "Take one snapshot of direct subagent conversations known to this parent session. This is not a completion wait or polling mechanism.",
@@ -454,6 +560,17 @@ export default function subagentsExtension(pi: ExtensionAPI) {
     },
   });
 
+  pi.registerCommand("subtree", {
+    description: "Show this parent's active ownership subtree",
+    handler: async (_args, ctx) => {
+      const status = buildOwnershipStatus(lineage.depth, controller.activeSubtree());
+      ctx.ui.notify([
+        "Active ownership subtree (IDs are scoped to the runtime's direct owner):",
+        ...status.lines,
+      ].join("\n"), "info");
+    },
+  });
+
   pi.registerCommand("sublist", {
     description: "List direct subagents known to this parent session",
     handler: async (_args, ctx) => {
@@ -464,6 +581,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 
   pi.on("session_start", (_event, ctx) => {
     ui = ctx.ui;
+    uiMode = ctx.mode;
     refreshUi();
   });
 
@@ -471,8 +589,15 @@ export default function subagentsExtension(pi: ExtensionAPI) {
     if (timer) clearInterval(timer);
     timer = undefined;
     await controller.shutdown();
-    ui?.setWidget("subagents", undefined);
-    ui?.setStatus("subagents", undefined);
+    if (uiMode === "tui") {
+      ui?.setWidget("subagents", undefined);
+      ui?.setStatus("subagents", undefined);
+    }
+    if (lineage.depth > 1 && uiMode === "rpc") {
+      ui?.setStatus(OWNERSHIP_STATUS_KEY, undefined);
+    }
+    publishedOwnershipStatus = undefined;
     ui = undefined;
+    uiMode = undefined;
   });
 }

--- a/extensions/subagents/inheritance.test.ts
+++ b/extensions/subagents/inheritance.test.ts
@@ -244,6 +244,26 @@ describe("subagent routing inheritance", () => {
     });
   });
 
+  it("preserves compact direct-child activity for a root RPC client", async () => {
+    const { tools, ctx, startSession, statuses, widgets } = setup();
+    await startSession("rpc");
+
+    await tools.get("subagent_start").execute(
+      "start",
+      { prompt: "root RPC child", name: "worker" },
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    expect(statuses.at(-1)).toEqual({ key: "subagents", text: "subagents: 1" });
+    expect(widgets.at(-1)).toMatchObject({
+      key: "subagents",
+      lines: [expect.stringContaining("#1 worker · running")],
+    });
+    expect(statuses.some((status) => status.key === "ompi:subagents:ownership-v1")).toBe(false);
+  });
+
   it("returns nested active state only when ownership status is requested", async () => {
     const { tools, ctx } = setup();
     await tools.get("subagent_start").execute(

--- a/extensions/subagents/inheritance.test.ts
+++ b/extensions/subagents/inheritance.test.ts
@@ -10,7 +10,8 @@ const rpc = vi.hoisted(() => ({
   children: [] as Array<{
     closed: boolean;
     requests: Array<Record<string, unknown>>;
-    emit(event: { type: string; message?: { role?: string; stopReason?: string } }): void;
+    onDialog?: (request: any, signal: AbortSignal) => Promise<any>;
+    emit(event: any): void;
   }>,
 }));
 
@@ -21,14 +22,20 @@ vi.mock("./rpc-child.ts", async (importOriginal) => {
     RpcSubprocess: class {
       closed = false;
       requests: Array<Record<string, unknown>> = [];
-      private listeners: Array<(event: { type: string; message?: { role?: string; stopReason?: string } }) => void> = [];
+      private listeners: Array<(event: any) => void> = [];
       private readonly sessionFile: string;
       private readonly capabilities: {
         tools: Array<{ name: string; provider: string }>;
         extensionPaths: string[];
       };
 
-      constructor(invocation: { args: string[]; env?: NodeJS.ProcessEnv }) {
+      readonly onDialog?: (request: any, signal: AbortSignal) => Promise<any>;
+
+      constructor(
+        invocation: { args: string[]; env?: NodeJS.ProcessEnv },
+        options?: { onDialog?: (request: any, signal: AbortSignal) => Promise<any> },
+      ) {
+        this.onDialog = options?.onDialog;
         rpc.invocations.push({ args: invocation.args, env: invocation.env });
         const sessionIndex = invocation.args.indexOf("--session");
         this.sessionFile = sessionIndex >= 0
@@ -54,7 +61,7 @@ vi.mock("./rpc-child.ts", async (importOriginal) => {
         return this.capabilities;
       }
 
-      onEvent(listener: (event: { type: string; message?: { role?: string; stopReason?: string } }) => void): () => void {
+      onEvent(listener: (event: any) => void): () => void {
         this.listeners.push(listener);
         return () => undefined;
       }
@@ -63,7 +70,7 @@ vi.mock("./rpc-child.ts", async (importOriginal) => {
         return () => undefined;
       }
 
-      emit(event: { type: string; message?: { role?: string; stopReason?: string } }): void {
+      emit(event: any): void {
         for (const listener of this.listeners) listener(event);
       }
 
@@ -86,6 +93,7 @@ function setup() {
   const commands = new Map<string, any>();
   const messages: unknown[] = [];
   const activityEvents: Array<{ channel: string; data: unknown }> = [];
+  const handlers = new Map<string, Array<(event: unknown, ctx: ExtensionContext) => unknown>>();
   let thinking = "low";
   let activeTools = ["read", "bash", "edit", "write"];
   let configuredTools = ["read", "bash", "edit", "write", "grep", "find", "ls"].map((name) => ({
@@ -103,7 +111,9 @@ function setup() {
     registerTool: (tool: { name: string }) => tools.set(tool.name, tool),
     registerCommand: (name: string, command: unknown) => commands.set(name, command),
     registerMessageRenderer: () => undefined,
-    on: () => undefined,
+    on: (event: string, handler: (event: unknown, ctx: ExtensionContext) => unknown) => {
+      handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+    },
     getThinkingLevel: () => thinking,
     getActiveTools: () => [...activeTools],
     getAllTools: () => configuredTools.map((tool) => ({ ...tool })),
@@ -113,10 +123,18 @@ function setup() {
     },
   } as unknown as ExtensionAPI;
   const notifications: string[] = [];
+  const statuses: Array<{ key: string; text?: string }> = [];
+  const widgets: Array<{ key: string; lines?: string[] }> = [];
   const ctx = {
     cwd: "/repo",
+    mode: "tui",
     model: { provider: "provider", id: "first" },
-    ui: { notify: (message: string) => notifications.push(message) },
+    ui: {
+      notify: (message: string) => notifications.push(message),
+      setWidget: (key: string, lines?: string[]) => widgets.push({ key, lines }),
+      setStatus: (key: string, text?: string) => statuses.push({ key, text }),
+      theme: { fg: (_color: string, text: string) => text },
+    },
   } as unknown as ExtensionContext;
 
   subagentsExtension(pi);
@@ -126,7 +144,15 @@ function setup() {
     ctx,
     messages,
     notifications,
+    statuses,
+    widgets,
     activityEvents,
+    startSession: async (mode: ExtensionContext["mode"] = "tui") => {
+      (ctx as any).mode = mode;
+      for (const handler of handlers.get("session_start") ?? []) {
+        await handler({ type: "session_start", reason: "startup" }, ctx);
+      }
+    },
     setThinking: (level: string) => { thinking = level; },
     setCapabilities: (
       active: string[],
@@ -216,6 +242,166 @@ describe("subagent routing inheritance", () => {
       channel: "ompi:async-activity",
       data: { source: "subagents", active: 0 },
     });
+  });
+
+  it("returns nested active state only when ownership status is requested", async () => {
+    const { tools, ctx } = setup();
+    await tools.get("subagent_start").execute(
+      "start",
+      { prompt: "coordinate", name: "coordinator" },
+      undefined,
+      undefined,
+      ctx,
+    );
+    rpc.children[0].emit({
+      type: "subagent_ownership",
+      ownership: [{
+        path: [7],
+        parentPath: [],
+        id: 7,
+        depth: 3,
+        state: "running",
+        name: "leaf",
+        model: "provider/leaf",
+        thinking: "medium",
+      }],
+    });
+
+    const result = await tools.get("subagent_status").execute();
+    expect(result.details.nodes).toEqual([
+      { runtimeId: "self", depth: 1, state: "current" },
+      expect.objectContaining({
+        runtimeId: "1",
+        parentRuntimeId: "self",
+        managementId: 1,
+        depth: 2,
+        state: "running",
+        name: "coordinator",
+      }),
+      expect.objectContaining({
+        runtimeId: "1/7",
+        parentRuntimeId: "1",
+        managementId: 7,
+        depth: 3,
+        state: "running",
+        name: "leaf",
+      }),
+    ]);
+    expect(result.content[0].text).not.toContain("coordinate");
+  });
+
+  it("relays a child dialog mechanically to the root TUI", async () => {
+    const { tools, ctx, startSession, messages } = setup();
+    const dialogs: unknown[] = [];
+    (ctx.ui as any).confirm = async (title: string, message: string, options: unknown) => {
+      dialogs.push({ title, message, options });
+      return true;
+    };
+    await startSession("tui");
+    await tools.get("subagent_start").execute(
+      "start",
+      { prompt: "ask the user" },
+      undefined,
+      undefined,
+      ctx,
+    );
+    const relay = rpc.children[0].onDialog;
+    expect(relay).toBeDefined();
+    if (!relay) throw new Error("Child dialog relay was not installed.");
+    const signal = new AbortController().signal;
+
+    await expect(relay({
+      id: "dialog-1",
+      method: "confirm",
+      title: "Approve?",
+      message: "Continue with the operation?",
+    }, signal)).resolves.toEqual({ confirmed: true });
+    expect(dialogs).toEqual([{
+      title: "Approve?",
+      message: "Continue with the operation?",
+      options: { signal, timeout: 30_000 },
+    }]);
+    expect(messages).toEqual([]);
+  });
+
+  it("fails a root headless dialog closed without invoking a parent model or UI", async () => {
+    const { tools, ctx, startSession } = setup();
+    (ctx.ui as any).confirm = async () => {
+      throw new Error("Headless root UI must not be called.");
+    };
+    await startSession("rpc");
+    await tools.get("subagent_start").execute(
+      "start",
+      { prompt: "ask without a root TUI" },
+      undefined,
+      undefined,
+      ctx,
+    );
+    const relay = rpc.children[0].onDialog;
+    if (!relay) throw new Error("Child dialog relay was not installed.");
+
+    await expect(relay({
+      id: "dialog-2",
+      method: "confirm",
+      title: "Approve?",
+      message: "No TUI exists.",
+    }, new AbortController().signal)).resolves.toEqual({ cancelled: true });
+  });
+
+  it("allows a nested RPC owner to forward a dialog to its parent transport", async () => {
+    process.env.OMPI_SUBAGENT_LINEAGE = JSON.stringify({
+      version: 1,
+      depth: 2,
+      maxDepth: 3,
+      maxChildren: 2,
+    });
+    const { tools, ctx, startSession, statuses, widgets } = setup();
+    const forwarded: string[] = [];
+    (ctx.ui as any).input = async (title: string) => {
+      forwarded.push(title);
+      return "root user value";
+    };
+    await startSession("rpc");
+    await tools.get("subagent_start").execute(
+      "start",
+      { prompt: "nested leaf" },
+      undefined,
+      undefined,
+      ctx,
+    );
+    const ownershipStatus = statuses.findLast(
+      (status) => status.key === "ompi:subagents:ownership-v1",
+    );
+    expect(JSON.parse(ownershipStatus?.text ?? "")).toEqual({
+      version: 1,
+      ownership: [{
+        path: [1],
+        parentPath: [],
+        id: 1,
+        depth: 3,
+        state: "running",
+        model: "provider/first",
+        thinking: "low",
+      }],
+    });
+    expect(ownershipStatus?.text).not.toContain("nested leaf");
+    expect(statuses.every((status) => status.key === "ompi:subagents:ownership-v1")).toBe(true);
+    expect(widgets).toEqual([]);
+    const relay = rpc.children[0].onDialog;
+    if (!relay) throw new Error("Nested child dialog relay was not installed.");
+
+    await expect(relay({
+      id: "dialog-3",
+      method: "input",
+      title: "Value from root user",
+    }, new AbortController().signal)).resolves.toEqual({ value: "root user value" });
+    expect(forwarded).toEqual(["Value from root user"]);
+
+    await settle(0);
+    const clearedStatus = statuses.findLast(
+      (status) => status.key === "ompi:subagents:ownership-v1",
+    );
+    expect(JSON.parse(clearedStatus?.text ?? "")).toEqual({ version: 1, ownership: [] });
   });
 
   it("inherits each then-active extension tool and provider on start and continuation", async () => {

--- a/extensions/subagents/native-nesting.test.ts
+++ b/extensions/subagents/native-nesting.test.ts
@@ -310,6 +310,12 @@ describe("native nested subagents", () => {
       if (!cancelledCoordinator || !cancelledLeaf) {
         throw new Error("Cancellation lineage processes were not observed.");
       }
+      await vi.waitFor(() => {
+        expect(controller.activeSubtree()).toEqual(expect.arrayContaining([
+          expect.objectContaining({ path: [2], depth: 2, state: "running" }),
+          expect.objectContaining({ path: [2, 1], parentPath: [2], depth: 3, state: "running" }),
+        ]));
+      });
       cancellation.abort();
       await expect(cancelling).resolves.toMatchObject({
         outcome: "interrupted",
@@ -317,6 +323,7 @@ describe("native nested subagents", () => {
       });
       expect(processIsAlive(cancelledCoordinator.pid)).toBe(false);
       expect(processIsAlive(cancelledLeaf.pid)).toBe(false);
+      expect(controller.activeSubtree()).toEqual([]);
 
       await controller.start({
         prompt: "SHUTDOWN",

--- a/extensions/subagents/native-nesting.test.ts
+++ b/extensions/subagents/native-nesting.test.ts
@@ -63,7 +63,7 @@ function textStream(model, text) {
   return stream;
 }
 
-function toolStream(model, prompt) {
+function toolStream(model, id, name, arguments_) {
   const stream = createAssistantMessageEventStream();
   const partial = {
     role: "assistant",
@@ -77,9 +77,9 @@ function toolStream(model, prompt) {
   };
   const toolCall = {
     type: "toolCall",
-    id: "call_leaf",
-    name: "subagent_start",
-    arguments: { prompt, delivery: "direct" },
+    id,
+    name,
+    arguments: arguments_,
   };
   const message = { ...partial, content: [toolCall] };
   queueMicrotask(() => {
@@ -121,27 +121,43 @@ function hangingStream(model, signal) {
 
 function streamFixture(model, context, options) {
   const userText = lastUserText(context.messages);
-  const toolResult = context.messages.findLast((message) =>
+  const subagentResult = context.messages.findLast((message) =>
     message.role === "toolResult" && message.toolName === "subagent_start"
+  );
+  const dialogResult = context.messages.findLast((message) =>
+    message.role === "toolResult" && message.toolName === "fixture_dialog"
   );
   const phase = userText === "LEAF"
     ? "leaf"
     : userText === "HANG"
       ? "leaf-hang"
-      : toolResult
-        ? "coordinator-after"
-        : "coordinator-before";
+      : userText === "DIALOG_LEAF"
+        ? dialogResult
+          ? "dialog-leaf-after"
+          : "dialog-leaf-before"
+        : subagentResult
+          ? "coordinator-after"
+          : "coordinator-before";
   appendFileSync(process.env.OMPI_NESTED_CAPTURE, JSON.stringify({
     phase,
     pid: process.pid,
-    toolResult: toolResult?.content,
+    toolResult: subagentResult?.content ?? dialogResult?.content,
   }) + "\n");
   if (phase === "coordinator-before") {
-    return toolStream(
-      model,
-      userText === "SHUTDOWN" || userText === "CANCEL" ? "HANG" : "LEAF",
-    );
+    const prompt = userText === "SHUTDOWN" || userText === "CANCEL"
+      ? "HANG"
+      : userText === "DIALOG"
+        ? "DIALOG_LEAF"
+        : "LEAF";
+    return toolStream(model, "call_leaf", "subagent_start", {
+      prompt,
+      delivery: "direct",
+    });
   }
+  if (phase === "dialog-leaf-before") {
+    return toolStream(model, "call_dialog", "fixture_dialog", {});
+  }
+  if (phase === "dialog-leaf-after") return textStream(model, "leaf dialog completed");
   if (phase === "leaf") return textStream(model, "leaf done");
   if (phase === "leaf-hang") return hangingStream(model, options?.signal);
   return textStream(model, "coordinator received leaf");
@@ -155,6 +171,20 @@ export default function fixtureProvider(pi) {
     parameters: Type.Object({}),
     async execute() {
       return { content: [{ type: "text", text: "fixture tool" }] };
+    },
+  });
+  pi.registerTool({
+    name: "fixture_dialog",
+    label: "Fixture Dialog",
+    description: "Requests one deterministic standard confirmation",
+    parameters: Type.Object({}),
+    async execute(_id, _params, signal, _onUpdate, ctx) {
+      const confirmed = await ctx.ui.confirm(
+        "Nested approval",
+        "Approve the depth-3 fixture?",
+        { signal, timeout: 5_000 },
+      );
+      return { content: [{ type: "text", text: "confirmed: " + confirmed }] };
     },
   });
   pi.registerProvider("fixture", {
@@ -220,9 +250,11 @@ describe("native nested subagents", () => {
       tools: [
         { name: "subagent_start", provider: SUBAGENT_EXTENSION },
         { name: "fixture_tool", provider: providerPath },
+        { name: "fixture_dialog", provider: providerPath },
       ],
       extensionPaths: [SUBAGENT_EXTENSION, providerPath],
     };
+    const relayedDialogs: unknown[] = [];
     const controller = new SubagentController({
       handshakeMs: 10_000,
       createChild: async (spec) => {
@@ -231,6 +263,13 @@ describe("native nested subagents", () => {
           ...invocation,
           command: process.execPath,
           args: [PI_CLI, ...invocation.args],
+        }, {
+          onDialog: async (request) => {
+            relayedDialogs.push(request);
+            return request.method === "confirm"
+              ? { confirmed: true }
+              : { cancelled: true };
+          },
         });
       },
       onPong: () => {
@@ -281,6 +320,43 @@ describe("native nested subagents", () => {
       expect(persistedLeafSession).toContain("LEAF");
       expect(persistedLeafSession).toContain("leaf done");
 
+      const dialogResult = await controller.run({
+        prompt: "DIALOG",
+        cwd,
+        model: "fixture/model",
+        thinking: "off",
+        capabilities,
+        maxDepth: 3,
+        maxChildren: 2,
+      });
+      expect(dialogResult).toMatchObject({
+        outcome: "completed",
+        finalText: "coordinator received leaf",
+      });
+      expect(relayedDialogs).toEqual([{
+        id: expect.any(String),
+        method: "confirm",
+        title: "Nested approval",
+        message: "Approve the depth-3 fixture?",
+        timeout: 5_000,
+      }]);
+      const dialogCaptures = (await readFile(capturePath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      expect(dialogCaptures.map((capture) => capture.phase)).toEqual([
+        "coordinator-before",
+        "leaf",
+        "coordinator-after",
+        "coordinator-before",
+        "dialog-leaf-before",
+        "dialog-leaf-after",
+        "coordinator-after",
+      ]);
+      expect(dialogCaptures[5].toolResult).toEqual([
+        { type: "text", text: "confirmed: true" },
+      ]);
+
       const cancellation = new AbortController();
       const cancelling = controller.run({
         prompt: "CANCEL",
@@ -312,8 +388,8 @@ describe("native nested subagents", () => {
       }
       await vi.waitFor(() => {
         expect(controller.activeSubtree()).toEqual(expect.arrayContaining([
-          expect.objectContaining({ path: [2], depth: 2, state: "running" }),
-          expect.objectContaining({ path: [2, 1], parentPath: [2], depth: 3, state: "running" }),
+          expect.objectContaining({ path: [3], depth: 2, state: "running" }),
+          expect.objectContaining({ path: [3, 1], parentPath: [3], depth: 3, state: "running" }),
         ]));
       });
       cancellation.abort();

--- a/extensions/subagents/ownership.ts
+++ b/extensions/subagents/ownership.ts
@@ -107,11 +107,14 @@ function parseRuntime(value: unknown): OwnershipRuntime {
 }
 
 export function encodeOwnershipStatus(ownership: OwnershipRuntime[]): string {
-  const safe = ownership.map((runtime) => ({
-    ...runtime,
-    name: runtime.name ? oneLine(runtime.name, MAX_NAME_LENGTH) : undefined,
-    model: oneLine(runtime.model, MAX_MODEL_LENGTH),
-  }));
+  const safe = ownership.map((runtime) => {
+    const name = runtime.name ? oneLine(runtime.name, MAX_NAME_LENGTH) : undefined;
+    return {
+      ...runtime,
+      name: name || undefined,
+      model: oneLine(runtime.model, MAX_MODEL_LENGTH),
+    };
+  });
   const encoded = JSON.stringify({ version: 1, ownership: safe });
   if (Buffer.byteLength(encoded, "utf8") > MAX_FRAME_BYTES) invalid();
   return JSON.stringify({ version: 1, ownership: safe.map(parseRuntime) });

--- a/extensions/subagents/ownership.ts
+++ b/extensions/subagents/ownership.ts
@@ -1,0 +1,155 @@
+import type {
+  ActiveSubagentState,
+  OwnershipRuntime,
+  ThinkingLevel,
+} from "./controller.ts";
+
+export const OWNERSHIP_STATUS_KEY = "ompi:subagents:ownership-v1";
+
+const MAX_FRAME_BYTES = 16_000;
+const MAX_RUNTIMES = 32;
+const MAX_RELATIVE_PATH = 2;
+const MAX_NAME_LENGTH = 80;
+const MAX_MODEL_LENGTH = 160;
+const ACTIVE_STATES = new Set<ActiveSubagentState>([
+  "handshaking",
+  "running",
+  "steering",
+  "interrupting",
+  "finalizing",
+]);
+const THINKING_LEVELS = new Set<ThinkingLevel>([
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+]);
+
+function invalid(): never {
+  throw new Error("Managed subagent ownership status is invalid.");
+}
+
+function oneLine(value: string, limit: number): string {
+  const compact = value.replace(/\s+/g, " ").trim();
+  return compact.length > limit ? compact.slice(0, limit) : compact;
+}
+
+function positiveId(value: unknown): value is number {
+  return Number.isSafeInteger(value) && Number(value) > 0;
+}
+
+function validPath(value: unknown): value is number[] {
+  return Array.isArray(value)
+    && value.length > 0
+    && value.length <= MAX_RELATIVE_PATH
+    && value.every(positiveId);
+}
+
+function samePath(left: number[], right: number[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function parseRuntime(value: unknown): OwnershipRuntime {
+  if (!value || typeof value !== "object" || Array.isArray(value)) invalid();
+  const candidate = value as Partial<OwnershipRuntime>;
+  if (
+    !validPath(candidate.path)
+    || !Array.isArray(candidate.parentPath)
+    || candidate.parentPath.some((id) => !positiveId(id))
+    || !samePath(candidate.parentPath, candidate.path.slice(0, -1))
+    || !positiveId(candidate.id)
+    || candidate.id !== candidate.path.at(-1)
+    || typeof candidate.depth !== "number"
+    || !Number.isInteger(candidate.depth)
+    || candidate.depth < 2
+    || candidate.depth > 3
+    || typeof candidate.state !== "string"
+    || !ACTIVE_STATES.has(candidate.state as ActiveSubagentState)
+    || typeof candidate.model !== "string"
+    || candidate.model.length === 0
+    || candidate.model.length > MAX_MODEL_LENGTH
+    || /[\r\n]/.test(candidate.model)
+    || typeof candidate.thinking !== "string"
+    || !THINKING_LEVELS.has(candidate.thinking as ThinkingLevel)
+    || (candidate.name !== undefined && (
+      typeof candidate.name !== "string"
+      || candidate.name.length === 0
+      || candidate.name.length > MAX_NAME_LENGTH
+      || /[\r\n]/.test(candidate.name)
+    ))
+  ) {
+    invalid();
+  }
+  const allowedKeys = new Set([
+    "path",
+    "parentPath",
+    "id",
+    "depth",
+    "state",
+    "name",
+    "model",
+    "thinking",
+  ]);
+  if (Object.keys(value).some((key) => !allowedKeys.has(key))) invalid();
+  return {
+    path: [...candidate.path],
+    parentPath: [...candidate.parentPath],
+    id: candidate.id,
+    depth: candidate.depth,
+    state: candidate.state as ActiveSubagentState,
+    name: candidate.name,
+    model: candidate.model,
+    thinking: candidate.thinking as ThinkingLevel,
+  };
+}
+
+export function encodeOwnershipStatus(ownership: OwnershipRuntime[]): string {
+  const safe = ownership.map((runtime) => ({
+    ...runtime,
+    name: runtime.name ? oneLine(runtime.name, MAX_NAME_LENGTH) : undefined,
+    model: oneLine(runtime.model, MAX_MODEL_LENGTH),
+  }));
+  const encoded = JSON.stringify({ version: 1, ownership: safe });
+  if (Buffer.byteLength(encoded, "utf8") > MAX_FRAME_BYTES) invalid();
+  return JSON.stringify({ version: 1, ownership: safe.map(parseRuntime) });
+}
+
+export function parseOwnershipStatus(value: unknown): OwnershipRuntime[] {
+  if (typeof value !== "string" || Buffer.byteLength(value, "utf8") > MAX_FRAME_BYTES) invalid();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch (error) {
+    throw new Error("Managed subagent ownership status is not valid JSON.", { cause: error });
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) invalid();
+  const candidate = parsed as { version?: unknown; ownership?: unknown };
+  if (
+    candidate.version !== 1
+    || !Array.isArray(candidate.ownership)
+    || candidate.ownership.length > MAX_RUNTIMES
+    || Object.keys(parsed).some((key) => key !== "version" && key !== "ownership")
+  ) {
+    invalid();
+  }
+  const ownership = candidate.ownership.map(parseRuntime);
+  const paths = new Set<string>();
+  const ownerDepths = new Set<number>();
+  for (const runtime of ownership) {
+    const path = runtime.path.join("/");
+    const parent = runtime.parentPath.join("/");
+    if (paths.has(path) || (parent && !paths.has(parent))) invalid();
+    paths.add(path);
+    ownerDepths.add(runtime.depth - runtime.path.length);
+  }
+  if (
+    ownerDepths.size > 1
+    || [...ownerDepths].some((depth) => depth < 1 || depth > 2)
+  ) {
+    invalid();
+  }
+  return ownership;
+}

--- a/extensions/subagents/presentation.test.ts
+++ b/extensions/subagents/presentation.test.ts
@@ -1,7 +1,12 @@
 import { initTheme, type ExtensionAPI, type MessageRenderer } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 import type { SubagentView, TerminalResult } from "./controller.ts";
-import subagentsExtension, { buildActiveUi, buildDirectResult, buildPongMessage } from "./index.ts";
+import subagentsExtension, {
+  buildActiveUi,
+  buildDirectResult,
+  buildOwnershipStatus,
+  buildPongMessage,
+} from "./index.ts";
 
 function view(overrides: Partial<SubagentView>): SubagentView {
   return {
@@ -38,6 +43,33 @@ describe("subagent tool guidance", () => {
   });
 });
 
+describe("ownership status operation", () => {
+  it("registers an on-demand active subtree tool and command without changing the default widget", async () => {
+    const tools = new Map<string, any>();
+    const commands = new Map<string, any>();
+    const pi = {
+      registerTool: (tool: { name: string }) => tools.set(tool.name, tool),
+      registerCommand: (name: string, command: unknown) => commands.set(name, command),
+      registerMessageRenderer: () => undefined,
+      on: () => undefined,
+      getThinkingLevel: () => "medium",
+      sendMessage: () => undefined,
+      events: { emit: () => undefined },
+    } as unknown as ExtensionAPI;
+
+    subagentsExtension(pi);
+
+    expect(tools.has("subagent_status")).toBe(true);
+    expect(commands.has("subtree")).toBe(true);
+    expect(tools.get("subagent_status").description).toContain("active ownership subtree");
+    const result = await tools.get("subagent_status").execute();
+    expect(result.content[0].text).toContain("self · depth 1 · current");
+    expect(result.details.nodes).toEqual([
+      { runtimeId: "self", depth: 1, state: "current" },
+    ]);
+  });
+});
+
 describe("subagent presentation", () => {
   it("shows only active work and the minimal concurrent footer count", () => {
     const presentation = buildActiveUi([
@@ -51,6 +83,40 @@ describe("subagent presentation", () => {
     expect(presentation.lines?.[0]).toContain("#1 reader · running · 3s · provider/model · reasoning medium · read · visible progress");
     expect(presentation.lines?.join(" ")).not.toContain("#3");
     expect(buildActiveUi([view({ active: false, state: "completed" })], 5_000)).toEqual({});
+  });
+
+  it("builds an on-demand active ownership tree with owner-scoped runtime IDs", () => {
+    const status = buildOwnershipStatus(2, [{
+      path: [3],
+      parentPath: [],
+      id: 3,
+      depth: 3,
+      state: "interrupting",
+      name: "leaf",
+      model: "provider/model",
+      thinking: "high",
+    }]);
+
+    expect(status.lines[0]).toContain("self · depth 2 · current");
+    expect(status.lines[1]).toContain("runtime 3 (leaf)");
+    expect(status.lines[1]).toContain("depth 3 · interrupting");
+    expect(status.lines[1]).toContain("parent self");
+    expect(status.lines[1]).toContain("owner-local ID #3");
+    expect(status.nodes).toEqual([
+      { runtimeId: "self", depth: 2, state: "current" },
+      {
+        runtimeId: "3",
+        parentRuntimeId: "self",
+        managementId: 3,
+        depth: 3,
+        state: "interrupting",
+        name: "leaf",
+        model: "provider/model",
+        thinking: "high",
+      },
+    ]);
+    expect(JSON.stringify(status)).not.toContain("preview");
+    expect(JSON.stringify(status)).not.toContain("finalText");
   });
 
   it("collapses final assistant text behind Pi's native expansion state", () => {

--- a/extensions/subagents/rpc-child.test.ts
+++ b/extensions/subagents/rpc-child.test.ts
@@ -1,6 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
 import { BUILTIN_TOOL_PROVIDER } from "./capabilities.ts";
-import { buildChildInvocation } from "./rpc-child.ts";
+import {
+  parseStandardDialogRequest,
+  relayStandardDialog,
+  STANDARD_DIALOG_METHODS,
+} from "./dialogs.ts";
+import {
+  OWNERSHIP_STATUS_KEY,
+  encodeOwnershipStatus,
+  parseOwnershipStatus,
+} from "./ownership.ts";
+import { buildChildInvocation, RpcSubprocess } from "./rpc-child.ts";
 
 function valueAfter(args: string[], flag: string): string | undefined {
   const index = args.indexOf(flag);
@@ -10,6 +21,302 @@ function valueAfter(args: string[], flag: string): string | undefined {
 function valuesAfter(args: string[], flag: string): string[] {
   return args.flatMap((value, index) => value === flag ? [args[index + 1]] : []);
 }
+
+const DIALOG_CHILD_SCRIPT = String.raw`
+  let buffer = "";
+  let commandId;
+  const dialog = JSON.parse(process.env.DIALOG_REQUEST);
+  const deadline = setTimeout(() => process.exit(2), 1000);
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (chunk) => {
+    buffer += chunk;
+    while (true) {
+      const newline = buffer.indexOf("\n");
+      if (newline < 0) return;
+      const line = buffer.slice(0, newline);
+      buffer = buffer.slice(newline + 1);
+      const message = JSON.parse(line);
+      if (message.type === "trigger") {
+        commandId = message.id;
+        process.stdout.write(JSON.stringify(dialog) + "\n");
+      } else if (message.type === "extension_ui_response") {
+        clearTimeout(deadline);
+        process.stdout.write(JSON.stringify({
+          type: "response",
+          id: commandId,
+          command: "trigger",
+          success: true,
+          data: message,
+        }) + "\n");
+      }
+    }
+  });
+`;
+
+function dialogChildInvocation(dialog: Record<string, unknown>) {
+  return {
+    command: process.execPath,
+    args: ["-e", DIALOG_CHILD_SCRIPT],
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      DIALOG_REQUEST: JSON.stringify({ type: "extension_ui_request", ...dialog }),
+    },
+  };
+}
+
+describe("ownership status protocol", () => {
+  it("round-trips a bounded active subtree without transcript fields", () => {
+    const ownership = [{
+      path: [2],
+      parentPath: [],
+      id: 2,
+      depth: 3,
+      state: "running" as const,
+      name: "leaf",
+      model: "provider/model",
+      thinking: "medium" as const,
+    }];
+
+    const encoded = encodeOwnershipStatus(ownership);
+
+    expect(OWNERSHIP_STATUS_KEY).toBe("ompi:subagents:ownership-v1");
+    expect(parseOwnershipStatus(encoded)).toEqual(ownership);
+    expect(encoded).not.toContain("preview");
+    expect(encoded).not.toContain("finalText");
+    expect(() => parseOwnershipStatus(JSON.stringify({
+      version: 1,
+      ownership: [{ ...ownership[0], path: [2, 3, 4] }],
+    }))).toThrow("invalid");
+  });
+});
+
+describe("standard dialog relay", () => {
+  it("uses only the user UI and preserves method-appropriate responses", async () => {
+    const calls: unknown[] = [];
+    const ui = {
+      select: async (title: string, options: string[], settings: unknown) => {
+        calls.push({ method: "select", title, options, settings });
+        return "Allow";
+      },
+      confirm: async (title: string, message: string, settings: unknown) => {
+        calls.push({ method: "confirm", title, message, settings });
+        return false;
+      },
+      input: async (title: string, placeholder: string, settings: unknown) => {
+        calls.push({ method: "input", title, placeholder, settings });
+        return "typed";
+      },
+      editor: async (title: string, prefill: string) => {
+        calls.push({ method: "editor", title, prefill });
+        return "edited";
+      },
+    } as unknown as ExtensionUIContext;
+    const signal = new AbortController().signal;
+
+    await expect(relayStandardDialog(ui, {
+      id: "1",
+      method: "select",
+      title: "Choose",
+      options: ["Allow", "Block"],
+    }, signal)).resolves.toEqual({ value: "Allow" });
+    await expect(relayStandardDialog(ui, {
+      id: "2",
+      method: "confirm",
+      title: "Continue",
+      message: "Proceed?",
+    }, signal)).resolves.toEqual({ confirmed: false });
+    await expect(relayStandardDialog(ui, {
+      id: "3",
+      method: "input",
+      title: "Value",
+      placeholder: "type",
+    }, signal)).resolves.toEqual({ value: "typed" });
+    await expect(relayStandardDialog(ui, {
+      id: "4",
+      method: "editor",
+      title: "Edit",
+      prefill: "before",
+    }, signal)).resolves.toEqual({ value: "edited" });
+
+    expect(calls).toHaveLength(4);
+    expect(calls[0]).toMatchObject({
+      method: "select",
+      settings: { timeout: 30_000, signal },
+    });
+    expect(calls[1]).toMatchObject({ method: "confirm" });
+    expect(calls[2]).toMatchObject({ method: "input" });
+  });
+
+  it("fails closed when the user UI does not settle before the relay deadline", async () => {
+    const ui = {
+      confirm: async () => new Promise<boolean>(() => undefined),
+    } as unknown as ExtensionUIContext;
+    const relaying = relayStandardDialog(ui, {
+      id: "slow",
+      method: "confirm",
+      title: "Continue?",
+      message: "No response",
+      timeout: 5,
+    }, new AbortController().signal);
+    const observed = await Promise.race([
+      relaying,
+      new Promise<"hung">((resolve) => setTimeout(() => resolve("hung"), 25)),
+    ]);
+
+    expect(observed).toEqual({ cancelled: true });
+  });
+
+  it("keeps TUI-only custom components outside the standard relay protocol", () => {
+    expect(STANDARD_DIALOG_METHODS).toEqual(["select", "confirm", "input", "editor"]);
+    expect(() => parseStandardDialogRequest({
+      type: "extension_ui_request",
+      id: "custom-1",
+      method: "custom",
+      title: "Unsupported",
+    })).toThrow("invalid");
+  });
+});
+
+describe("RpcSubprocess dialog transport", () => {
+  it("correlates a standard child dialog with the relay response", async () => {
+    const requests: unknown[] = [];
+    const child = new RpcSubprocess(dialogChildInvocation({
+      id: "child-dialog-7",
+      method: "select",
+      title: "Allow?",
+      options: ["Allow", "Block"],
+    }), {
+      onDialog: async (request) => {
+        requests.push(request);
+        return { value: "Allow" };
+      },
+    });
+
+    await expect(child.request({ type: "trigger" })).resolves.toEqual({
+      type: "extension_ui_response",
+      id: "child-dialog-7",
+      value: "Allow",
+    });
+    expect(requests).toEqual([{
+      id: "child-dialog-7",
+      method: "select",
+      title: "Allow?",
+      options: ["Allow", "Block"],
+    }]);
+    await child.close();
+  });
+
+  it("fails a standard dialog closed immediately when no relay is available", async () => {
+    const child = new RpcSubprocess(dialogChildInvocation({
+      id: "child-dialog-8",
+      method: "confirm",
+      title: "Continue?",
+      message: "This needs a user decision.",
+    }));
+
+    await expect(child.request({ type: "trigger" })).resolves.toEqual({
+      type: "extension_ui_response",
+      id: "child-dialog-8",
+      cancelled: true,
+    });
+    await child.close();
+  });
+
+  it("cancels and settles a pending dialog before process cleanup", async () => {
+    let relayStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      relayStarted = resolve;
+    });
+    let aborted = false;
+    const child = new RpcSubprocess(dialogChildInvocation({
+      id: "child-dialog-9",
+      method: "input",
+      title: "Value",
+    }), {
+      onDialog: async (_request, signal) => {
+        relayStarted();
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => {
+            aborted = true;
+            resolve();
+          }, { once: true });
+        });
+        return { value: "too late" };
+      },
+    });
+
+    const requesting = child.request({ type: "trigger" });
+    await started;
+    const closing = child.close();
+    await expect(requesting).resolves.toEqual({
+      type: "extension_ui_response",
+      id: "child-dialog-9",
+      cancelled: true,
+    });
+    await closing;
+    expect(aborted).toBe(true);
+  });
+});
+
+describe("RpcSubprocess ownership transport", () => {
+  it("intercepts a strict JSONL ownership frame and forwards only validated status", async () => {
+    const ownership = [{
+      path: [2],
+      parentPath: [],
+      id: 2,
+      depth: 3,
+      state: "running" as const,
+      name: "leaf\u2028runtime",
+      model: "provider/model",
+      thinking: "medium" as const,
+    }];
+    const status = JSON.stringify({ version: 1, ownership });
+    const script = String.raw`
+      process.stdout.write(JSON.stringify({
+        type: "extension_ui_request",
+        id: "status-1",
+        method: "setStatus",
+        statusKey: process.env.STATUS_KEY,
+        statusText: process.env.STATUS_TEXT,
+      }) + "\n");
+      let buffer = "";
+      process.stdin.setEncoding("utf8");
+      process.stdin.on("data", (chunk) => {
+        buffer += chunk;
+        const newline = buffer.indexOf("\n");
+        if (newline < 0) return;
+        const command = JSON.parse(buffer.slice(0, newline));
+        process.stdout.write(JSON.stringify({
+          type: "response",
+          id: command.id,
+          command: command.type,
+          success: true,
+          data: "pong",
+        }) + "\n");
+      });
+    `;
+    const child = new RpcSubprocess({
+      command: process.execPath,
+      args: ["-e", script],
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        STATUS_KEY: OWNERSHIP_STATUS_KEY,
+        STATUS_TEXT: status,
+      },
+    });
+    const events: unknown[] = [];
+    child.onEvent((event) => events.push(event));
+
+    await expect(child.request({ type: "ping" })).resolves.toBe("pong");
+    await vi.waitFor(() => expect(events).toEqual([{
+      type: "subagent_ownership",
+      ownership,
+    }]));
+    await child.close();
+  });
+});
 
 describe("buildChildInvocation", () => {
   it("creates a clean Pi launch with exact tools, required providers, and normal resource discovery", () => {

--- a/extensions/subagents/rpc-child.test.ts
+++ b/extensions/subagents/rpc-child.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import { initTheme, type ExtensionUIContext } from "@earendil-works/pi-coding-agent";
 import { BUILTIN_TOOL_PROVIDER } from "./capabilities.ts";
 import {
   parseStandardDialogRequest,
@@ -89,6 +89,29 @@ describe("ownership status protocol", () => {
       ownership: [{ ...ownership[0], path: [2, 3, 4] }],
     }))).toThrow("invalid");
   });
+
+  it("omits a whitespace-only optional name instead of rejecting active status", () => {
+    const encoded = encodeOwnershipStatus([{
+      path: [1],
+      parentPath: [],
+      id: 1,
+      depth: 3,
+      state: "handshaking",
+      name: "   ",
+      model: "provider/model",
+      thinking: "low",
+    }]);
+
+    expect(parseOwnershipStatus(encoded)).toEqual([{
+      path: [1],
+      parentPath: [],
+      id: 1,
+      depth: 3,
+      state: "handshaking",
+      model: "provider/model",
+      thinking: "low",
+    }]);
+  });
 });
 
 describe("standard dialog relay", () => {
@@ -165,6 +188,34 @@ describe("standard dialog relay", () => {
     ]);
 
     expect(observed).toEqual({ cancelled: true });
+  });
+
+  it("dismisses the root interactive editor when its bounded relay expires", async () => {
+    initTheme(undefined, false);
+    let customSettled = false;
+    const ui = {
+      custom: async (factory: (...args: any[]) => unknown) => new Promise<string | undefined>((resolve, reject) => {
+        const done = (value: string | undefined) => {
+          customSettled = true;
+          resolve(value);
+        };
+        Promise.resolve(factory(
+          { requestRender: () => undefined },
+          {},
+          {},
+          done,
+        )).catch(reject);
+      }),
+    } as unknown as ExtensionUIContext;
+
+    await expect(relayStandardDialog(ui, {
+      id: "editor-deadline",
+      method: "editor",
+      title: "Edit",
+      prefill: "draft",
+      timeout: 5,
+    }, new AbortController().signal, { interactiveEditor: true })).resolves.toEqual({ cancelled: true });
+    expect(customSettled).toBe(true);
   });
 
   it("keeps TUI-only custom components outside the standard relay protocol", () => {

--- a/extensions/subagents/rpc-child.ts
+++ b/extensions/subagents/rpc-child.ts
@@ -8,8 +8,22 @@ import {
   parseCapabilityProbe,
   type CapabilitySnapshot,
 } from "./capabilities.ts";
-import type { LaunchSpec, RpcChild, RpcEvent } from "./controller.ts";
+import type {
+  LaunchSpec,
+  OwnershipRuntime,
+  RpcChild,
+  RpcEvent,
+} from "./controller.ts";
+import {
+  cancelledDialogResult,
+  isStandardDialogMethod,
+  normalizeDialogResult,
+  parseStandardDialogRequest,
+  type StandardDialogRequest,
+  type StandardDialogResult,
+} from "./dialogs.ts";
 import { MANAGED_LINEAGE_ENV, encodeManagedLineage } from "./lineage.ts";
+import { OWNERSHIP_STATUS_KEY, parseOwnershipStatus } from "./ownership.ts";
 
 interface RpcResponse {
   id?: string;
@@ -25,7 +39,16 @@ interface PendingRequest {
   timer: NodeJS.Timeout;
 }
 
+interface PendingDialog {
+  abort: AbortController;
+}
+
+export interface RpcSubprocessOptions {
+  onDialog?(request: StandardDialogRequest, signal: AbortSignal): Promise<StandardDialogResult>;
+}
+
 const CAPABILITY_PROBE_PATH = fileURLToPath(new URL("./capability-probe.ts", import.meta.url));
+const MAX_RPC_FRAME_BYTES = 512 * 1024;
 
 export interface ChildInvocation {
   command: string;
@@ -73,6 +96,7 @@ export function buildChildInvocation(spec: LaunchSpec): ChildInvocation {
 export class RpcSubprocess implements RpcChild {
   private readonly process: ChildProcessWithoutNullStreams;
   private readonly pending = new Map<string, PendingRequest>();
+  private readonly pendingDialogs = new Map<string, PendingDialog>();
   private readonly eventListeners: Array<(event: RpcEvent) => void> = [];
   private readonly exitListeners: Array<(error?: Error) => void> = [];
   private requestId = 0;
@@ -84,7 +108,10 @@ export class RpcSubprocess implements RpcChild {
   private resolveCapabilities!: (snapshot: CapabilitySnapshot) => void;
   private rejectCapabilities!: (error: Error) => void;
 
-  constructor(invocation: ChildInvocation) {
+  constructor(
+    invocation: ChildInvocation,
+    private readonly options: RpcSubprocessOptions = {},
+  ) {
     this.exitPromise = new Promise((resolve) => {
       this.resolveExit = resolve;
     });
@@ -157,6 +184,7 @@ export class RpcSubprocess implements RpcChild {
 
   async close(): Promise<void> {
     if (this.exited) return;
+    this.cancelPendingDialogs(true);
     this.process.stdin.end();
     const timeout = setTimeout(() => this.process.kill("SIGTERM"), 2_000);
     const killTimeout = setTimeout(() => this.process.kill("SIGKILL"), 4_000);
@@ -175,14 +203,32 @@ export class RpcSubprocess implements RpcChild {
         if (newline < 0) break;
         let line = buffer.slice(0, newline);
         buffer = buffer.slice(newline + 1);
+        if (Buffer.byteLength(line, "utf8") > MAX_RPC_FRAME_BYTES) {
+          this.rejectOversizedFrame();
+          buffer = "";
+          return;
+        }
         if (line.endsWith("\r")) line = line.slice(0, -1);
         this.handleLine(line);
+      }
+      if (Buffer.byteLength(buffer, "utf8") > MAX_RPC_FRAME_BYTES) {
+        this.rejectOversizedFrame();
+        buffer = "";
       }
     });
     this.process.stdout.on("end", () => {
       buffer += decoder.end();
+      if (Buffer.byteLength(buffer, "utf8") > MAX_RPC_FRAME_BYTES) {
+        this.rejectOversizedFrame();
+        return;
+      }
       if (buffer) this.handleLine(buffer.endsWith("\r") ? buffer.slice(0, -1) : buffer);
     });
+  }
+
+  private rejectOversizedFrame(): void {
+    this.stderr = `${this.stderr} Child RPC stdout frame exceeded ${MAX_RPC_FRAME_BYTES} bytes.`.slice(-8_000);
+    this.process.kill("SIGTERM");
   }
 
   private handleLine(line: string): void {
@@ -209,6 +255,34 @@ export class RpcSubprocess implements RpcChild {
       }
       return;
     }
+    if (
+      message.type === "extension_ui_request"
+      && "method" in message
+      && isStandardDialogMethod(message.method)
+    ) {
+      this.handleDialog(message);
+      return;
+    }
+    if (
+      message.type === "extension_ui_request"
+      && "method" in message
+      && message.method === "setStatus"
+      && "statusKey" in message
+      && message.statusKey === OWNERSHIP_STATUS_KEY
+    ) {
+      let ownership: OwnershipRuntime[] = [];
+      try {
+        ownership = "statusText" in message && message.statusText !== undefined
+          ? parseOwnershipStatus(message.statusText)
+          : [];
+      } catch {
+        // Invalid child status fails closed instead of preserving stale descendants.
+      }
+      for (const listener of this.eventListeners) {
+        listener({ type: "subagent_ownership", ownership });
+      }
+      return;
+    }
     if (message.type === "response" && "id" in message && message.id) {
       const pending = this.pending.get(message.id);
       if (!pending) return;
@@ -227,8 +301,56 @@ export class RpcSubprocess implements RpcChild {
     const exitError = error ?? new Error("Child RPC process exited.");
     this.rejectCapabilities(exitError);
     this.rejectPending(exitError);
+    this.cancelPendingDialogs(false);
     this.resolveExit();
     for (const listener of this.exitListeners) listener(error);
+  }
+
+  private handleDialog(message: RpcResponse | RpcEvent): void {
+    const rawId = "id" in message ? message.id : undefined;
+    let request: StandardDialogRequest;
+    try {
+      request = parseStandardDialogRequest(message);
+    } catch {
+      if (typeof rawId === "string" && rawId.length > 0 && rawId.length <= 128) {
+        this.writeDialogResponse(rawId, cancelledDialogResult());
+      }
+      return;
+    }
+    if (this.pendingDialogs.has(request.id)) {
+      this.writeDialogResponse(request.id, cancelledDialogResult());
+      return;
+    }
+    if (!this.options.onDialog) {
+      this.writeDialogResponse(request.id, cancelledDialogResult());
+      return;
+    }
+    const abort = new AbortController();
+    this.pendingDialogs.set(request.id, { abort });
+    void this.options.onDialog(request, abort.signal)
+      .then((result) => normalizeDialogResult(request, result))
+      .catch(() => cancelledDialogResult())
+      .then((result) => {
+        if (!this.pendingDialogs.delete(request.id)) return;
+        this.writeDialogResponse(request.id, result);
+      });
+  }
+
+  private writeDialogResponse(id: string, result: StandardDialogResult): void {
+    if (this.exited || !this.process.stdin.writable) return;
+    this.process.stdin.write(`${JSON.stringify({
+      type: "extension_ui_response",
+      id,
+      ...result,
+    })}\n`, "utf8", () => undefined);
+  }
+
+  private cancelPendingDialogs(respond: boolean): void {
+    for (const [id, pending] of this.pendingDialogs) {
+      if (respond) this.writeDialogResponse(id, cancelledDialogResult());
+      pending.abort.abort();
+    }
+    this.pendingDialogs.clear();
   }
 
   private rejectPending(error: Error): void {


### PR DESCRIPTION
## Summary

- add an on-demand ownership-scoped active subtree without changing the compact default presentation
- relay standard headless RPC dialogs through direct owners to the root TUI with bounded fail-closed behavior
- preserve recursive lifecycle semantics and add protocol, presentation, cleanup, and native multi-hop coverage

## Verification

- `npm test` — 19 files, 174 tests passed
- `npm run typecheck` — passed
- `git diff --check 2a1b55caeb96ab2fef3306daff3b4beb20041155...HEAD` — passed

Closes #27
