### PR TITLE
fix: accept model-sized subagent RPC frames

### DIFF
--- a/extensions/subagents/rpc-child.test.ts
+++ b/extensions/subagents/rpc-child.test.ts
@@ -65,6 +65,41 @@ function dialogChildInvocation(dialog: Record<string, unknown>) {
   };
 }
 
+const FRAME_CHILD_SCRIPT = String.raw`
+  let buffer = "";
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (chunk) => {
+    buffer += chunk;
+    const newline = buffer.indexOf("\n");
+    if (newline < 0) return;
+    const command = JSON.parse(buffer.slice(0, newline));
+    process.stdout.write(JSON.stringify({
+      type: "response",
+      id: command.id,
+      command: command.type,
+      success: true,
+      data: "pong",
+    }) + "\n");
+    const text = "x".repeat(Number(process.env.FRAME_TEXT_BYTES));
+    process.stdout.write(JSON.stringify({
+      type: "agent_end",
+      messages: [{ role: "assistant", content: [{ type: "text", text }] }],
+    }) + "\n");
+  });
+`;
+
+function frameChildInvocation(frameTextBytes: number) {
+  return {
+    command: process.execPath,
+    args: ["-e", FRAME_CHILD_SCRIPT],
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      FRAME_TEXT_BYTES: String(frameTextBytes),
+    },
+  };
+}
+
 describe("ownership status protocol", () => {
   it("round-trips a bounded active subtree without transcript fields", () => {
     const ownership = [{
@@ -365,6 +400,32 @@ describe("RpcSubprocess ownership transport", () => {
       type: "subagent_ownership",
       ownership,
     }]));
+    await child.close();
+  });
+});
+
+describe("RpcSubprocess frame bounds", () => {
+  it("accepts valid protocol frames above the legacy 512 KiB limit", async () => {
+    const child = new RpcSubprocess(frameChildInvocation(1024 * 1024));
+    const observed = new Promise<"event" | "exit">((resolve) => {
+      child.onEvent((event) => {
+        if (event.type === "agent_end") resolve("event");
+      });
+      child.onExit(() => resolve("exit"));
+    });
+
+    await expect(child.request({ type: "ping" })).resolves.toBe("pong");
+    await expect(observed).resolves.toBe("event");
+    await child.close();
+  });
+
+  it("terminates frames above the 8 MiB safety bound", async () => {
+    const child = new RpcSubprocess(frameChildInvocation(8 * 1024 * 1024));
+    const exited = new Promise<Error | undefined>((resolve) => child.onExit(resolve));
+
+    await expect(child.request({ type: "ping" })).resolves.toBe("pong");
+    const error = await exited;
+    expect(error?.message).toContain("Child RPC stdout frame exceeded 8388608 bytes.");
     await child.close();
   });
 });

--- a/extensions/subagents/rpc-child.test.ts
+++ b/extensions/subagents/rpc-child.test.ts
@@ -67,24 +67,39 @@ function dialogChildInvocation(dialog: Record<string, unknown>) {
 
 const FRAME_CHILD_SCRIPT = String.raw`
   let buffer = "";
+  let frameCommand;
   process.stdin.setEncoding("utf8");
   process.stdin.on("data", (chunk) => {
     buffer += chunk;
-    const newline = buffer.indexOf("\n");
-    if (newline < 0) return;
-    const command = JSON.parse(buffer.slice(0, newline));
-    process.stdout.write(JSON.stringify({
-      type: "response",
-      id: command.id,
-      command: command.type,
-      success: true,
-      data: "pong",
-    }) + "\n");
-    const text = "x".repeat(Number(process.env.FRAME_TEXT_BYTES));
-    process.stdout.write(JSON.stringify({
-      type: "agent_end",
-      messages: [{ role: "assistant", content: [{ type: "text", text }] }],
-    }) + "\n");
+    while (true) {
+      const newline = buffer.indexOf("\n");
+      if (newline < 0) return;
+      const command = JSON.parse(buffer.slice(0, newline));
+      buffer = buffer.slice(newline + 1);
+      if (command.type === "emit_frame") {
+        frameCommand = command;
+        const text = "x".repeat(Number(process.env.FRAME_TEXT_BYTES));
+        process.stdout.write(JSON.stringify({
+          type: "agent_end",
+          messages: [{ role: "assistant", content: [{ type: "text", text }] }],
+        }) + "\n");
+        continue;
+      }
+      process.stdout.write(JSON.stringify({
+        type: "response",
+        id: frameCommand.id,
+        command: frameCommand.type,
+        success: true,
+        data: "frame accepted",
+      }) + "\n");
+      process.stdout.write(JSON.stringify({
+        type: "response",
+        id: command.id,
+        command: command.type,
+        success: true,
+        data: "pong",
+      }) + "\n");
+    }
   });
 `;
 
@@ -405,17 +420,20 @@ describe("RpcSubprocess ownership transport", () => {
 });
 
 describe("RpcSubprocess frame bounds", () => {
-  it("accepts valid protocol frames above the legacy 512 KiB limit", async () => {
+  it("accepts a valid model-sized frame and settles following responses", async () => {
     const child = new RpcSubprocess(frameChildInvocation(1024 * 1024));
-    const observed = new Promise<"event" | "exit">((resolve) => {
+    const followingResponse = new Promise<unknown>((resolve, reject) => {
       child.onEvent((event) => {
-        if (event.type === "agent_end") resolve("event");
+        if (event.type === "agent_end") {
+          void child.request({ type: "after_frame" }).then(resolve, reject);
+        }
       });
-      child.onExit(() => resolve("exit"));
+      child.onExit((error) => reject(error ?? new Error("Child exited before the large frame settled.")));
     });
 
-    await expect(child.request({ type: "ping" })).resolves.toBe("pong");
-    await expect(observed).resolves.toBe("event");
+    const frameResponse = child.request({ type: "emit_frame" });
+    await expect(followingResponse).resolves.toBe("pong");
+    await expect(frameResponse).resolves.toBe("frame accepted");
     await child.close();
   });
 
@@ -423,9 +441,12 @@ describe("RpcSubprocess frame bounds", () => {
     const child = new RpcSubprocess(frameChildInvocation(8 * 1024 * 1024));
     const exited = new Promise<Error | undefined>((resolve) => child.onExit(resolve));
 
-    await expect(child.request({ type: "ping" })).resolves.toBe("pong");
+    const request = expect(child.request({ type: "emit_frame" })).rejects.toThrow(
+      "Child RPC stdout frame exceeded 8388608 bytes.",
+    );
     const error = await exited;
     expect(error?.message).toContain("Child RPC stdout frame exceeded 8388608 bytes.");
+    await request;
     await child.close();
   });
 });

--- a/extensions/subagents/rpc-child.ts
+++ b/extensions/subagents/rpc-child.ts
@@ -48,7 +48,8 @@ export interface RpcSubprocessOptions {
 }
 
 const CAPABILITY_PROBE_PATH = fileURLToPath(new URL("./capability-probe.ts", import.meta.url));
-const MAX_RPC_FRAME_BYTES = 512 * 1024;
+// Pi's agent_end frame carries the complete turn messages, so legitimate long turns need model-sized headroom.
+const MAX_RPC_FRAME_BYTES = 8 * 1024 * 1024;
 
 export interface ChildInvocation {
   command: string;


### PR DESCRIPTION
## Summary

- raise the bounded child RPC JSONL frame allowance from 512 KiB to 8 MiB
- cover a valid 1 MiB `agent_end` frame and prove following RPC responses still settle
- preserve fail-closed termination and exact diagnostics above the 8 MiB bound

## Verification

- regression reproduced twice against the legacy 512 KiB limit
- `npm test -- extensions/subagents/rpc-child.test.ts` — 14/14 passed
- `npm test` — 19 files / 176 tests passed
- `npm run typecheck`
- `git diff --check bd64e683ff9a8c5bbab9d9f628babf8fee632951...HEAD`
- one fresh isolated read-only review found the missing post-frame transport assertion; coordinator correction added it

Closes #32
