### PR TITLE
fix: accept image-sized Pi RPC records

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,9 @@ the default: a call returns after child RPC prompt acceptance and later queues
 exactly one completion, failure, or interruption pong. Set `delivery` to
 `"direct"` explicitly when dependent work must receive the bounded terminal
 result through the pending tool call; direct delivery emits no later pong.
-Independent direct siblings issued together still run concurrently.
+Independent direct siblings issued together still run concurrently. Child
+transport follows Pi's strict JSONL framing without a smaller ompi-specific
+record cap; parent-visible terminal text remains bounded separately.
 
 The normal widget and footer remain compact and show only direct current
 activity. They never stream child transcripts into the parent conversation or

--- a/docs/subagents/CONTEXT.md
+++ b/docs/subagents/CONTEXT.md
@@ -53,7 +53,7 @@ A new subagent conversation that receives the inherited runtime baseline and its
 _Avoid_: Context fork, implicit transcript inheritance, automatic conversation sharing
 
 **Subagent extension**:
-The mechanical Pi extension that connects each parent agent to direct subagents and owns their managed process lifecycle, message transport, local limits, and status for the current session. It does not decide or interpret delegated work.
+The mechanical Pi extension that connects each parent agent to direct subagents and owns their managed process lifecycle, message transport, local limits, and status for the current session. Its child transport follows Pi's strict JSONL record semantics and does not terminate valid records at a smaller extension-specific byte cap; bounded terminal results and status metadata remain separate parent-visible limits. It does not decide or interpret delegated work.
 _Avoid_: Agent, daemon, orchestration platform, scheduler, workflow engine
 
 **Steering**:

--- a/extensions/subagents/rpc-child.test.ts
+++ b/extensions/subagents/rpc-child.test.ts
@@ -78,10 +78,19 @@ const FRAME_CHILD_SCRIPT = String.raw`
       buffer = buffer.slice(newline + 1);
       if (command.type === "emit_frame") {
         frameCommand = command;
-        const text = "x".repeat(Number(process.env.FRAME_TEXT_BYTES));
+        const totalBytes = Number(process.env.FRAME_TEXT_BYTES);
+        const imageCount = 6;
+        const imageBytes = Math.ceil(totalBytes / imageCount);
         process.stdout.write(JSON.stringify({
           type: "agent_end",
-          messages: [{ role: "assistant", content: [{ type: "text", text }] }],
+          messages: Array.from({ length: imageCount }, (_, index) => ({
+            role: "toolResult",
+            toolCallId: "read-image-" + index,
+            toolName: "read",
+            content: [{ type: "image", data: "A".repeat(imageBytes), mimeType: "image/png" }],
+            isError: false,
+            timestamp: index,
+          })),
         }) + "\n");
         continue;
       }
@@ -419,7 +428,7 @@ describe("RpcSubprocess ownership transport", () => {
   });
 });
 
-describe("RpcSubprocess frame bounds", () => {
+describe("RpcSubprocess frame transport", () => {
   it("accepts a valid model-sized frame and settles following responses", async () => {
     const child = new RpcSubprocess(frameChildInvocation(1024 * 1024));
     const followingResponse = new Promise<unknown>((resolve, reject) => {
@@ -437,16 +446,20 @@ describe("RpcSubprocess frame bounds", () => {
     await child.close();
   });
 
-  it("terminates frames above the 8 MiB safety bound", async () => {
-    const child = new RpcSubprocess(frameChildInvocation(8 * 1024 * 1024));
-    const exited = new Promise<Error | undefined>((resolve) => child.onExit(resolve));
+  it("accepts an image-bearing frame above 8 MiB and settles following responses", async () => {
+    const child = new RpcSubprocess(frameChildInvocation(10 * 1024 * 1024));
+    const followingResponse = new Promise<unknown>((resolve, reject) => {
+      child.onEvent((event) => {
+        if (event.type === "agent_end") {
+          void child.request({ type: "after_frame" }).then(resolve, reject);
+        }
+      });
+      child.onExit((error) => reject(error ?? new Error("Child exited before the image frame settled.")));
+    });
 
-    const request = expect(child.request({ type: "emit_frame" })).rejects.toThrow(
-      "Child RPC stdout frame exceeded 8388608 bytes.",
-    );
-    const error = await exited;
-    expect(error?.message).toContain("Child RPC stdout frame exceeded 8388608 bytes.");
-    await request;
+    const frameResponse = child.request({ type: "emit_frame" });
+    await expect(followingResponse).resolves.toBe("pong");
+    await expect(frameResponse).resolves.toBe("frame accepted");
     await child.close();
   });
 });

--- a/extensions/subagents/rpc-child.ts
+++ b/extensions/subagents/rpc-child.ts
@@ -48,8 +48,6 @@ export interface RpcSubprocessOptions {
 }
 
 const CAPABILITY_PROBE_PATH = fileURLToPath(new URL("./capability-probe.ts", import.meta.url));
-// Pi's agent_end frame carries the complete turn messages, so legitimate long turns need model-sized headroom.
-const MAX_RPC_FRAME_BYTES = 8 * 1024 * 1024;
 
 export interface ChildInvocation {
   command: string;
@@ -204,32 +202,14 @@ export class RpcSubprocess implements RpcChild {
         if (newline < 0) break;
         let line = buffer.slice(0, newline);
         buffer = buffer.slice(newline + 1);
-        if (Buffer.byteLength(line, "utf8") > MAX_RPC_FRAME_BYTES) {
-          this.rejectOversizedFrame();
-          buffer = "";
-          return;
-        }
         if (line.endsWith("\r")) line = line.slice(0, -1);
         this.handleLine(line);
-      }
-      if (Buffer.byteLength(buffer, "utf8") > MAX_RPC_FRAME_BYTES) {
-        this.rejectOversizedFrame();
-        buffer = "";
       }
     });
     this.process.stdout.on("end", () => {
       buffer += decoder.end();
-      if (Buffer.byteLength(buffer, "utf8") > MAX_RPC_FRAME_BYTES) {
-        this.rejectOversizedFrame();
-        return;
-      }
       if (buffer) this.handleLine(buffer.endsWith("\r") ? buffer.slice(0, -1) : buffer);
     });
-  }
-
-  private rejectOversizedFrame(): void {
-    this.stderr = `${this.stderr} Child RPC stdout frame exceeded ${MAX_RPC_FRAME_BYTES} bytes.`.slice(-8_000);
-    this.process.kill("SIGTERM");
   }
 
   private handleLine(line: string): void {


### PR DESCRIPTION
## Summary

- remove ompi's extension-specific 8 MiB child RPC JSONL record cap
- align child framing with Pi's official strict JSONL client behavior
- reproduce image-heavy `agent_end` aggregation above 8 MiB and prove following RPC responses settle
- document that transport records and bounded parent-visible terminal results are separate limits

## Incident evidence

The ephemeral Daily Paper Art session was deleted with its temporary container home, but its bind-mounted artifacts show the role completed: `30-art.md` is `READY` with `blocker: none`, both candidates exist, and the selected source is byte-identical to candidate B. The harness failed during terminal transport and published without the completed cover.

Pi 0.81.1 documents strict LF-delimited JSONL without a configurable record-size cap. Its official subprocess client buffers through LF without an explicit byte check. Choosing another arbitrary ompi cap would repeat #32.

## Verification

- red: >8 MiB image-bearing aggregate frame terminated with `Child RPC stdout frame exceeded 8388608 bytes`
- green: `npm test -- extensions/subagents/rpc-child.test.ts` — 14 passed
- `npm test` — 19 files / 176 tests passed
- `npm run typecheck`
- `git diff --check`

Closes #34
