### PR TITLE
feat(subagents): show direct and nested footer counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,13 +386,15 @@ Independent direct siblings issued together still run concurrently. Child
 transport follows Pi's strict JSONL framing without a smaller ompi-specific
 record cap; parent-visible terminal text remains bounded separately.
 
-The normal widget and footer remain compact and show only direct current
-activity. They never stream child transcripts into the parent conversation or
-render a recursive dashboard. When a user asks to inspect nesting,
-`subagent_status` or `/subtree` returns the active ownership subtree relative to
-the invoking parent: `self`, depth, state, parent runtime, and owner-local
-numeric ID. A nested parent therefore sees itself and descendants, not its
-parent, siblings, idle conversations, unrelated controllers, or other sessions.
+The normal widget remains compact and shows only direct current activity. The
+compact footer summarizes the active ownership subtree as `direct: N • nested:
+N • total: N`; it does not add recursive widget lines. Neither surface streams
+child transcripts into the parent conversation or renders a recursive
+dashboard. When a user asks to inspect nesting, `subagent_status` or `/subtree`
+returns the active ownership subtree relative to the invoking parent: `self`,
+depth, state, parent runtime, and owner-local numeric ID. A nested parent
+therefore sees itself and descendants, not its parent, siblings, idle
+conversations, unrelated controllers, or other sessions.
 Descendant paths explain ownership but are not new action identifiers; existing
 steer and interrupt operations still accept only the direct owner's local ID.
 

--- a/docs/subagents/CONTEXT.md
+++ b/docs/subagents/CONTEXT.md
@@ -85,7 +85,7 @@ One parent agent plus every active descendant runtime reachable through that par
 _Avoid_: Global agent registry, session inventory, machine process tree, globally actionable runtime ID
 
 **Live status**:
-A compact Pi widget near the editor that shows only direct current subagent activity without adding streaming updates to the parent conversation. The default stays non-recursive, and a minimal footer count remains visible while a direct subagent turn is active. The same direct active count is published through the shared extension event bus so session-level status integrations do not mistake a settled parent turn for an idle session. `subagent_status` and `/subtree` provide a user-requested, active-only ownership subtree; status propagation contains bounded runtime metadata, never prompts, transcript text, final text, unrelated sessions, or a permanent dashboard.
+A compact Pi widget near the editor that shows only direct current subagent activity without adding streaming updates to the parent conversation. The widget stays non-recursive, while the compact footer summarizes the active ownership subtree as `direct: N • nested: N • total: N`. The shared extension event bus continues to publish the direct active count, not the footer total, so session-level status integrations do not mistake a settled parent turn for an idle session. `subagent_status` and `/subtree` provide a user-requested, active-only ownership subtree; status propagation contains bounded runtime metadata, never prompts, transcript text, final text, unrelated sessions, or a permanent dashboard.
 _Avoid_: Transcript message, progress polling, full output, recursive default widget
 
 **Headless UI relay**:

--- a/extensions/subagents/index.ts
+++ b/extensions/subagents/index.ts
@@ -150,9 +150,14 @@ function boundedTerminalText(pong: TerminalResult): { text?: string; truncated: 
   return { text: pong.finalText.slice(0, TERMINAL_TEXT_LIMIT), truncated: true };
 }
 
-export function buildActiveUi(views: SubagentView[], now: number): { lines?: string[]; status?: string } {
+export function buildActiveUi(
+  views: SubagentView[],
+  now: number,
+  ownership: OwnershipRuntime[] = [],
+): { lines?: string[]; status?: string } {
   const active = views.filter((view) => view.active);
   if (active.length === 0) return {};
+  const nestedCount = ownership.filter((runtime) => runtime.path.length > 1).length;
   const lines = active.map((view) => {
     const elapsed = view.startedAt ? Math.max(0, Math.floor((now - view.startedAt) / 1_000)) : 0;
     const name = view.name ? ` ${oneLine(view.name, 20)}` : "";
@@ -161,7 +166,10 @@ export function buildActiveUi(views: SubagentView[], now: number): { lines?: str
     const preview = view.preview ? ` · ${oneLine(view.preview, 72)}` : "";
     return `#${view.id}${name} · ${view.state} · ${elapsed}s · ${model} · reasoning ${view.thinking}${tool}${preview}`;
   });
-  return { lines, status: `subagents: ${active.length}` };
+  return {
+    lines,
+    status: `direct: ${active.length} • nested: ${nestedCount} • total: ${active.length + nestedCount}`,
+  };
 }
 
 interface OwnershipStatusNode {
@@ -264,7 +272,8 @@ export default function subagentsExtension(pi: ExtensionAPI) {
   const refreshUi = () => {
     const views = controller.list();
     const activeCount = views.filter((view) => view.active).length;
-    const presentation = buildActiveUi(views, Date.now());
+    const ownership = controller.activeSubtree();
+    const presentation = buildActiveUi(views, Date.now(), ownership);
     if (
       ui
       && (uiMode === "tui" || (lineage.depth === 1 && uiMode === "rpc"))
@@ -280,7 +289,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
       );
     }
     if (ui && lineage.depth > 1 && uiMode === "rpc") {
-      const ownershipStatus = encodeOwnershipStatus(controller.activeSubtree());
+      const ownershipStatus = encodeOwnershipStatus(ownership);
       if (publishedOwnershipStatus !== ownershipStatus) {
         publishedOwnershipStatus = ownershipStatus;
         ui.setStatus(OWNERSHIP_STATUS_KEY, ownershipStatus);

--- a/extensions/subagents/inheritance.test.ts
+++ b/extensions/subagents/inheritance.test.ts
@@ -256,12 +256,59 @@ describe("subagent routing inheritance", () => {
       ctx,
     );
 
-    expect(statuses.at(-1)).toEqual({ key: "subagents", text: "subagents: 1" });
+    expect(statuses.at(-1)).toEqual({
+      key: "subagents",
+      text: "direct: 1 • nested: 0 • total: 1",
+    });
     expect(widgets.at(-1)).toMatchObject({
       key: "subagents",
       lines: [expect.stringContaining("#1 worker · running")],
     });
     expect(statuses.some((status) => status.key === "ompi:subagents:ownership-v1")).toBe(false);
+  });
+
+  it("refreshes and clears root footer counts from nested ownership", async () => {
+    const { tools, ctx, startSession, statuses, widgets } = setup();
+    await startSession("rpc");
+    await tools.get("subagent_start").execute(
+      "start",
+      { prompt: "coordinate", name: "coordinator" },
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    rpc.children[0].emit({
+      type: "subagent_ownership",
+      ownership: [{
+        path: [7],
+        parentPath: [],
+        id: 7,
+        depth: 3,
+        state: "running",
+        name: "leaf",
+        model: "provider/leaf",
+        thinking: "medium",
+      }],
+    });
+
+    expect(statuses.findLast((status) => status.key === "subagents")).toEqual({
+      key: "subagents",
+      text: "direct: 1 • nested: 1 • total: 2",
+    });
+    expect(widgets.at(-1)).toMatchObject({
+      key: "subagents",
+      lines: [expect.stringContaining("#1 coordinator · running")],
+    });
+    expect(widgets.at(-1)?.lines?.join(" ")).not.toContain("leaf");
+
+    await settle(0);
+
+    expect(statuses.findLast((status) => status.key === "subagents")).toEqual({
+      key: "subagents",
+      text: undefined,
+    });
+    expect(widgets.at(-1)).toEqual({ key: "subagents", lines: undefined });
   });
 
   it("returns nested active state only when ownership status is requested", async () => {

--- a/extensions/subagents/presentation.test.ts
+++ b/extensions/subagents/presentation.test.ts
@@ -1,6 +1,6 @@
 import { initTheme, type ExtensionAPI, type MessageRenderer } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it } from "vitest";
-import type { SubagentView, TerminalResult } from "./controller.ts";
+import type { OwnershipRuntime, SubagentView, TerminalResult } from "./controller.ts";
 import subagentsExtension, {
   buildActiveUi,
   buildDirectResult,
@@ -71,14 +71,32 @@ describe("ownership status operation", () => {
 });
 
 describe("subagent presentation", () => {
-  it("shows only active work and the minimal concurrent footer count", () => {
+  it("shows direct widget lines and direct, nested, and total footer counts", () => {
+    const ownership: OwnershipRuntime[] = [
+      {
+        path: [1], parentPath: [], id: 1, depth: 2, state: "running",
+        model: "provider/model", thinking: "medium",
+      },
+      {
+        path: [1, 7], parentPath: [1], id: 7, depth: 3, state: "running",
+        model: "provider/model", thinking: "medium",
+      },
+      {
+        path: [2], parentPath: [], id: 2, depth: 2, state: "finalizing",
+        model: "provider/model", thinking: "medium",
+      },
+      {
+        path: [2, 8], parentPath: [2], id: 8, depth: 3, state: "running",
+        model: "provider/model", thinking: "medium",
+      },
+    ];
     const presentation = buildActiveUi([
       view({ id: 1, name: "reader", currentTool: "read", preview: "visible progress" }),
       view({ id: 2, state: "finalizing" }),
       view({ id: 3, active: false, state: "completed" }),
-    ], 4_500);
+    ], 4_500, ownership);
 
-    expect(presentation.status).toBe("subagents: 2");
+    expect(presentation.status).toBe("direct: 2 • nested: 2 • total: 4");
     expect(presentation.lines).toHaveLength(2);
     expect(presentation.lines?.[0]).toContain("#1 reader · running · 3s · provider/model · reasoning medium · read · visible progress");
     expect(presentation.lines?.join(" ")).not.toContain("#3");


### PR DESCRIPTION
## Summary

- replace the direct-only `subagents: N` footer with compact direct, nested, and total active runtime counts
- keep widget lines direct-only while refreshing footer status from bounded ownership updates
- cover nested refresh and full cleanup at the presentation and root-session seams
- document the distinct widget, footer, `/subtree`, and shared activity-event contracts

## Verification

- `npm test` — 19 files / 177 tests passed
- `npm run typecheck` — passed
- `git diff --check` — passed

Closes #36
